### PR TITLE
Implemented ABI Analysis via Claude

### DIFF
--- a/tools/abi_analysis/__main__.py
+++ b/tools/abi_analysis/__main__.py
@@ -1,0 +1,144 @@
+"""
+tools/abi_analysis/__main__.py
+
+Recovers calling-convention / parameter-count / return-type / frame-shape
+info for every recompiled function, so tools.recomp can generate more
+accurate C signatures instead of falling back to its cdecl/0-param/int-or-void
+defaults for everything.
+
+Usage (matches the other pipeline tools' style):
+
+    py -3 -m tools.abi_analysis game_files/default.xbe
+
+    py -3 -m tools.abi_analysis game_files/default.xbe \
+        --functions tools/disasm/output/functions.json \
+        --identified tools/func_id/output/identified_functions.json \
+        --output-dir tools/abi_analysis/output \
+        -v
+
+Writes tools/abi_analysis/output/abi_functions.json by default, which is
+exactly where tools.recomp looks for it (see tools/recomp/__main__.py's
+--abi-dir default).
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from .analyzer import AbiAnalyzer
+from .xbe_min import XbeFile
+
+
+def find_data_files(disasm_dir=None, func_id_dir=None, overrides=None):
+    base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    disasm_dir = disasm_dir or os.path.join(base, "disasm", "output")
+    func_id_dir = func_id_dir or os.path.join(base, "func_id", "output")
+    paths = {
+        "functions": os.path.join(disasm_dir, "functions.json"),
+        "identified": os.path.join(func_id_dir, "identified_functions.json"),
+    }
+    overrides = overrides or {}
+    for key, val in overrides.items():
+        if val:
+            paths[key] = val
+    return paths
+
+
+def _load_json_list(path, label):
+    if not os.path.exists(path):
+        print(f"ERROR: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        # Tolerate either a bare list or a {"functions": [...]} wrapper.
+        for key in ("functions", "items", "entries"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        # Fall back to treating dict values as the entries.
+        return list(data.values())
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.abi_analysis",
+        description="Heuristic ABI recovery (calling convention, param "
+                     "count, return type, frame shape) for recompiled "
+                     "Xbox functions.")
+    parser.add_argument("xbe_path", help="Path to default.xbe")
+    parser.add_argument("--disasm-dir",
+                         help="Directory holding tools.disasm output "
+                              "(default: tools/disasm/output)")
+    parser.add_argument("--func-id-dir",
+                         help="Directory holding tools.func_id output "
+                              "(default: tools/func_id/output)")
+    parser.add_argument("--functions",
+                         help="Path to functions.json (overrides --disasm-dir)")
+    parser.add_argument("--identified",
+                         help="Path to identified_functions.json "
+                              "(overrides --func-id-dir)")
+    parser.add_argument("--output-dir",
+                         help="Output directory (default: "
+                              "tools/abi_analysis/output)")
+    parser.add_argument("--output",
+                         help="Full output path (overrides --output-dir); "
+                              "default: <output-dir>/abi_functions.json")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.xbe_path):
+        print(f"ERROR: XBE not found at {args.xbe_path}", file=sys.stderr)
+        sys.exit(1)
+
+    paths = find_data_files(
+        disasm_dir=args.disasm_dir,
+        func_id_dir=args.func_id_dir,
+        overrides={"functions": args.functions, "identified": args.identified},
+    )
+
+    functions = _load_json_list(paths["functions"], "functions.json")
+    identified = _load_json_list(paths["identified"], "identified_functions.json")
+
+    identified_by_addr = {}
+    for entry in identified:
+        addr = entry.get("start")
+        if addr is None:
+            continue
+        addr = int(addr, 16) if isinstance(addr, str) else int(addr)
+        identified_by_addr[addr] = entry
+
+    if args.verbose:
+        print(f"Loaded {len(functions)} functions, "
+              f"{len(identified_by_addr)} classifications")
+        print(f"Loading XBE from {args.xbe_path} ...")
+
+    xbe = XbeFile(args.xbe_path)
+
+    if args.verbose:
+        print(f"XBE base=0x{xbe.base_address:08X}, "
+              f"{len(xbe.sections)} sections")
+        for s in xbe.sections:
+            print(f"  {s}")
+
+    analyzer = AbiAnalyzer(xbe, functions, identified_by_addr,
+                            verbose=args.verbose)
+    results = analyzer.analyze_all()
+
+    output_dir = args.output_dir or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "output")
+    output_path = args.output or os.path.join(output_dir, "abi_functions.json")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+
+    thiscall_count = sum(1 for r in results
+                          if r["calling_convention"].startswith("thiscall"))
+    print(f"Wrote {len(results)} ABI entries to {output_path} "
+          f"({thiscall_count} detected as thiscall)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/abi_analysis/analyzer.py
+++ b/tools/abi_analysis/analyzer.py
@@ -1,0 +1,270 @@
+"""
+tools/abi_analysis/analyzer.py
+
+Heuristic ABI recovery for statically-recompiled Xbox functions.
+
+Consumes:
+  - tools/disasm/output/functions.json      (address ranges, has_prologue, etc.)
+  - tools/func_id/output/identified_functions.json  (category classifications)
+  - the original default.xbe                (to pull raw bytes for disasm)
+
+Produces a list of dicts shaped like:
+  {
+    "address": "0x00011000",
+    "calling_convention": "cdecl" | "thiscall" | "thiscall_cdecl",
+    "estimated_params": int,
+    "return_hint": "int_or_void" | "float" | "float_sse" | "int_zero",
+    "frame_type": "fpo_leaf" | "standard_frame",
+    "stack_frame_size": int,
+    "heuristic_confidence": float,   # extra, informational only
+    "heuristic_notes": str,          # extra, informational only
+  }
+
+matching what tools/recomp/translator.py expects from abi_functions.json
+(entry["address"] parsed via int(..., 16); the "calling_convention",
+"estimated_params", "return_hint", "frame_type", "stack_frame_size" keys
+read via abi_info.get(...) with the same fallback defaults used here).
+
+Every heuristic falls back to recomp's own defaults (cdecl / 0 params /
+int_or_void / fpo_leaf / 0) whenever confidence is low, so a bad guess is
+never worse than the current "no ABI data" behavior.
+"""
+
+try:
+    from capstone import Cs, CS_ARCH_X86, CS_MODE_32
+except ImportError as e:
+    raise ImportError(
+        "capstone is required for tools.abi_analysis (pip install capstone)"
+    ) from e
+
+
+VTABLE_CATEGORY_HINTS = ("vtable", "method", "virtual")
+
+# Categories we should NOT try to guess thiscall for, even if ecx looks
+# read-before-write - these are well-known non-C++-method categories where
+# ecx-as-first-read is more likely coincidental (e.g. CRT helpers that use
+# ecx as a scratch/loop register early on).
+NON_METHOD_CATEGORY_HINTS = ("crt", "kernel", "import", "thunk")
+
+
+def _parse_int_field(entry, *keys):
+    for k in keys:
+        if k in entry and entry[k] is not None:
+            v = entry[k]
+            if isinstance(v, str):
+                return int(v, 16) if v.lower().startswith("0x") else int(v)
+            return int(v)
+    return None
+
+
+def _looks_like_method_category(category):
+    if not category:
+        return False
+    cat = category.lower()
+    if any(h in cat for h in NON_METHOD_CATEGORY_HINTS):
+        return False
+    return any(h in cat for h in VTABLE_CATEGORY_HINTS)
+
+
+class AbiAnalyzer:
+    def __init__(self, xbe, functions, identified_by_addr, verbose=False):
+        """
+        xbe: xbe_min.XbeFile
+        functions: list of function dicts from disasm's functions.json
+        identified_by_addr: dict[int addr] -> func_id entry (for category)
+        """
+        self.xbe = xbe
+        self.functions = functions
+        self.identified_by_addr = identified_by_addr
+        self.verbose = verbose
+        self.md = Cs(CS_ARCH_X86, CS_MODE_32)
+        self.md.detail = False
+
+    def analyze_all(self):
+        results = []
+        skipped = 0
+        for func in self.functions:
+            entry = self._analyze_one(func)
+            if entry is None:
+                skipped += 1
+                continue
+            results.append(entry)
+        if self.verbose:
+            print(f"abi_analysis: analyzed {len(results)} functions, "
+                  f"skipped {skipped} (no readable bytes)")
+        return results
+
+    def _analyze_one(self, func):
+        start = _parse_int_field(func, "start", "address", "addr")
+        end = _parse_int_field(func, "end")
+        size = func.get("size")
+        if start is None:
+            return None
+        if size is None:
+            size = (end - start) if end is not None else 0
+        if size <= 0:
+            return None
+
+        section_hint = func.get("section")
+        raw = self.xbe.read_bytes_at_va(start, size, name_hint=section_hint)
+        if not raw:
+            return None
+
+        try:
+            insns = list(self.md.disasm(raw, start))
+        except Exception:
+            return None
+        if not insns:
+            return None
+
+        classification = self.identified_by_addr.get(start)
+        category = classification.get("category") if classification else None
+
+        cc, this_confident = self._detect_calling_convention(insns, category)
+        ret_imm = self._find_ret_immediate(insns)
+        params = self._estimate_params(insns, ret_imm, cc)
+        return_hint = self._detect_return_hint(insns)
+        frame_type, frame_size = self._detect_frame(func, insns)
+
+        confidence = 0.5
+        notes = []
+        if this_confident:
+            confidence += 0.25
+            notes.append("ecx-read-before-write + vtable category")
+        if ret_imm is not None:
+            confidence += 0.15
+            notes.append(f"ret cleaned {ret_imm} bytes")
+        if not notes:
+            notes.append("low-confidence default")
+
+        return {
+            "address": f"0x{start:08X}",
+            "calling_convention": cc,
+            "estimated_params": params,
+            "return_hint": return_hint,
+            "frame_type": frame_type,
+            "stack_frame_size": frame_size,
+            "heuristic_confidence": round(min(confidence, 1.0), 2),
+            "heuristic_notes": "; ".join(notes),
+        }
+
+    # ------------------------------------------------------------------
+    # Heuristics
+    # ------------------------------------------------------------------
+
+    def _detect_calling_convention(self, insns, category):
+        """
+        thiscall detection: ecx is read before it is ever written within
+        the function body, AND func_id's classification suggests this is a
+        C++ method (vtable-dispatched). Both signals required to keep the
+        false-positive rate low; MSVC thiscall passes `this` in ecx and the
+        callee typically uses it (member access) before clobbering it.
+        """
+        if not _looks_like_method_category(category):
+            return "cdecl", False
+
+        ecx_read_before_write = None
+        for insn in insns:
+            op = insn.op_str.replace(" ", "")
+            is_write_ecx = insn.mnemonic in ("mov", "lea", "pop", "xor") and \
+                op.startswith("ecx,")
+            is_pure_ecx_write = insn.mnemonic == "xor" and op == "ecx,ecx"
+            reads_ecx = "ecx" in op and not op.startswith("ecx,")
+            # xor ecx,ecx both reads and writes ecx as a zero-idiom; treat
+            # as a write, not evidence of "this" usage.
+            if is_pure_ecx_write:
+                ecx_read_before_write = False
+                break
+            if is_write_ecx:
+                ecx_read_before_write = False
+                break
+            if reads_ecx:
+                ecx_read_before_write = True
+                break
+        if ecx_read_before_write:
+            return "thiscall", True
+        return "cdecl", False
+
+    def _find_ret_immediate(self, insns):
+        for insn in reversed(insns):
+            if insn.mnemonic == "ret":
+                op = insn.op_str.strip()
+                if not op:
+                    return None
+                try:
+                    return int(op, 16) if op.lower().startswith("0x") else int(op)
+                except ValueError:
+                    return None
+        return None
+
+    def _estimate_params(self, insns, ret_imm, cc):
+        if ret_imm is not None:
+            return max(0, ret_imm // 4)
+        # Fallback: scan for the highest [ebp+N] stack-argument offset.
+        # ebp+4 is the return address, ebp+8 is the first argument.
+        max_off = 0
+        for insn in insns:
+            op = insn.op_str
+            if "ebp+" not in op and "ebp +" not in op:
+                continue
+            idx = op.find("ebp+")
+            if idx == -1:
+                idx = op.find("ebp +")
+                if idx == -1:
+                    continue
+                idx += 1  # skip the space variant consistently
+            frag = op[idx + 4:]
+            digits = ""
+            for ch in frag:
+                if ch in "0123456789abcdefABCDEFx":
+                    digits += ch
+                else:
+                    break
+            if not digits:
+                continue
+            try:
+                off = int(digits, 16) if "x" in digits.lower() or any(
+                    c in "abcdefABCDEF" for c in digits) else int(digits)
+            except ValueError:
+                continue
+            if off > max_off:
+                max_off = off
+        if max_off >= 8:
+            return max(0, (max_off - 4) // 4)
+        return 0
+
+    def _detect_return_hint(self, insns):
+        # Look at the tail of the function (last few insns before the
+        # final ret) for float-return or zero-return idioms.
+        tail = insns[-4:] if len(insns) >= 4 else insns
+        for insn in tail:
+            if insn.mnemonic.startswith("fstp"):
+                return "float_sse"
+        for i, insn in enumerate(tail):
+            if insn.mnemonic == "xor" and insn.op_str.replace(" ", "") == "eax,eax":
+                # Only counts if this is the last substantive insn before ret
+                rest = tail[i + 1:]
+                if all(r.mnemonic in ("ret", "nop") for r in rest):
+                    return "int_zero"
+        return "int_or_void"
+
+    def _detect_frame(self, func, insns):
+        has_prologue = func.get("has_prologue", False)
+        if not has_prologue:
+            return "fpo_leaf", 0
+        frame_size = 0
+        # Standard prologue: push ebp; mov ebp, esp; [sub esp, N]
+        for i in range(min(len(insns), 4) - 2):
+            if (insns[i].mnemonic == "push" and insns[i].op_str == "ebp" and
+                    insns[i + 1].mnemonic == "mov" and
+                    insns[i + 1].op_str.replace(" ", "") == "ebp,esp"):
+                nxt = insns[i + 2]
+                if nxt.mnemonic == "sub" and nxt.op_str.startswith("esp,"):
+                    imm = nxt.op_str.split(",", 1)[1].strip()
+                    try:
+                        frame_size = int(imm, 16) if imm.lower().startswith("0x") \
+                            else int(imm)
+                    except ValueError:
+                        frame_size = 0
+                break
+        return "standard_frame", frame_size

--- a/tools/abi_analysis/xbe_min.py
+++ b/tools/abi_analysis/xbe_min.py
@@ -1,0 +1,130 @@
+"""
+tools/abi_analysis/xbe_min.py
+
+Minimal, dependency-free XBE header + section table reader.
+
+Only implements what abi_analysis needs: mapping a function's Xbox virtual
+address to a file offset so its raw bytes can be pulled out and disassembled.
+Based on the public XBE file format (see docs/formats/xbe.md / xboxdevwiki).
+
+This intentionally does NOT try to be a full XBE parser (no cert parsing,
+no import table, no TLS, no logo bitmap, etc.) - just headers + sections.
+"""
+
+import struct
+
+
+class XbeSection:
+    __slots__ = ("name", "flags", "virtual_address", "virtual_size",
+                 "raw_address", "raw_size")
+
+    def __init__(self, name, flags, virtual_address, virtual_size,
+                 raw_address, raw_size):
+        self.name = name
+        self.flags = flags
+        self.virtual_address = virtual_address
+        self.virtual_size = virtual_size
+        self.raw_address = raw_address
+        self.raw_size = raw_size
+
+    def contains_va(self, va):
+        return self.virtual_address <= va < self.virtual_address + self.virtual_size
+
+    def __repr__(self):
+        return (f"<XbeSection {self.name!r} va=0x{self.virtual_address:08X} "
+                f"vsize=0x{self.virtual_size:X} raw=0x{self.raw_address:08X} "
+                f"rsize=0x{self.raw_size:X}>")
+
+
+class XbeFile:
+    """
+    Loads an XBE's header + section table and provides VA -> file-offset
+    mapping and raw byte reads. Keeps the whole file in memory since
+    original Xbox XBEs top out in the low tens of MB.
+    """
+
+    SECTION_HEADER_SIZE = 56
+
+    def __init__(self, path):
+        self.path = path
+        with open(path, "rb") as f:
+            self.data = f.read()
+
+        if self.data[0:4] != b"XBEH":
+            raise ValueError(f"{path}: not an XBE file (bad magic)")
+
+        # Offsets below are from the public XBE image header layout.
+        # Digital_Signature is 256 bytes starting right after the 4-byte
+        # magic, so Base_Address is at 4 + 256 = 0x104.
+        (self.base_address,) = struct.unpack_from("<I", self.data, 0x104)
+        (self.size_of_headers,) = struct.unpack_from("<I", self.data, 0x108)
+        (self.entry_point_raw,) = struct.unpack_from("<I", self.data, 0x128)
+        (self.num_sections,) = struct.unpack_from("<I", self.data, 0x11C)
+        (self.section_headers_va,) = struct.unpack_from("<I", self.data, 0x120)
+
+        self.sections = self._read_sections()
+
+    def _va_to_header_offset(self, va):
+        """
+        Only valid for addresses that live in the XBE header region itself
+        (e.g. the section header table, section name strings) - NOT for
+        addresses inside a section's own virtual range. The header region's
+        file offset 0 corresponds to virtual address `base_address`.
+        """
+        return va - self.base_address
+
+    def _read_cstring_at_va(self, va, max_len=64):
+        off = self._va_to_header_offset(va)
+        end = self.data.find(b"\x00", off, off + max_len)
+        if end == -1:
+            end = off + max_len
+        return self.data[off:end].decode("ascii", errors="replace")
+
+    def _read_sections(self):
+        sections = []
+        table_off = self._va_to_header_offset(self.section_headers_va)
+        for i in range(self.num_sections):
+            off = table_off + i * self.SECTION_HEADER_SIZE
+            (flags, virtual_address, virtual_size, raw_address, raw_size,
+             name_addr) = struct.unpack_from("<IIIIII", self.data, off)
+            name = self._read_cstring_at_va(name_addr)
+            sections.append(XbeSection(name, flags, virtual_address,
+                                        virtual_size, raw_address, raw_size))
+        return sections
+
+    def find_section(self, va, name_hint=None):
+        """
+        Find the section containing `va`. If name_hint is given (e.g. the
+        "section" field from functions.json, like ".text"), prefer an exact
+        name match among candidates that also contain the address, since
+        section virtual ranges can occasionally abut.
+        """
+        candidates = [s for s in self.sections if s.contains_va(va)]
+        if not candidates:
+            return None
+        if name_hint:
+            for s in candidates:
+                if s.name == name_hint:
+                    return s
+        return candidates[0]
+
+    def read_bytes_at_va(self, va, size, name_hint=None):
+        """
+        Read `size` raw bytes starting at virtual address `va`. Returns None
+        if the address doesn't fall in any known section, or if the read
+        would run past the section's raw (on-disk) data - which happens for
+        addresses in the tail of a section that's zero-padded in memory but
+        not backed by file bytes (bss-like tail).
+        """
+        section = self.find_section(va, name_hint)
+        if section is None:
+            return None
+        offset_in_section = va - section.virtual_address
+        if offset_in_section + size > section.raw_size:
+            # Falls into the virtual-only (zero-filled) tail of the section.
+            available = max(0, section.raw_size - offset_in_section)
+            if available <= 0:
+                return None
+            size = available
+        file_off = section.raw_address + offset_in_section
+        return self.data[file_off:file_off + size]


### PR DESCRIPTION
Using Claude I've implemented the missing abi_analysis tool.

This should resolve the warning message from tools.recomp and also allow a more complete recompilation.

`py -3 -m tools.abi_analysis path/to/default.xbe -v`

Then run the recomp tool as normal and it should emit at least another recomp_xxxx.c file.