### PR TITLE
fix(lifter): recover conditional tail calls, fallthrough, and indirect call targets

### DIFF
--- a/tools/disasm/__main__.py
+++ b/tools/disasm/__main__.py
@@ -68,17 +68,22 @@ def main():
     )
     parser.add_argument(
         "--seed-functions",
+        action="append",
         default=None,
         help="JSON file with additional function entry points to seed the detector. "
              "Format: array of objects with 'start' field (hex address string). "
-             "Use identified_functions.json from func_id to feed back vtable thunks.",
+             "May be repeated to merge seed sets.",
     )
 
     args = parser.parse_args()
 
     try:
         extra = [s.strip() for s in args.extra_sections.split(",")] if args.extra_sections else []
-        seed_funcs = _load_seed_functions(args.seed_functions) if args.seed_functions else []
+        seed_funcs = [
+            addr
+            for path in (args.seed_functions or [])
+            for addr in _load_seed_functions(path)
+        ]
         disassembler = Disassembler(
             xbe_path=args.xbe_path,
             analysis_json=args.analysis_json,

--- a/tools/recomp/disasm.py
+++ b/tools/recomp/disasm.py
@@ -144,6 +144,38 @@ class Disassembler:
         self._cs.detail = True
         _init_reg_names(self._cs)
 
+    def _decode_instruction(self, cs_insn):
+        """Convert one Capstone instruction into the translator model."""
+        insn = Instruction(
+            address=cs_insn.address,
+            size=cs_insn.size,
+            mnemonic=cs_insn.mnemonic,
+            op_str=cs_insn.op_str,
+            bytes_hex=cs_insn.bytes.hex(),
+        )
+
+        try:
+            ops = cs_insn.operands
+        except Exception:
+            ops = []
+        for cs_op in ops:
+            op = _parse_operand(self._cs, cs_op, cs_insn)
+            insn.operands.append(op)
+
+            if cs_op.type == CS_OP_IMM:
+                val = cs_op.imm & 0xFFFFFFFF
+                insn.imm_values.append(val)
+                if insn.is_call:
+                    insn.call_target = val
+                elif insn.is_branch:
+                    insn.jump_target = val
+            elif cs_op.type == CS_OP_MEM:
+                if (cs_op.mem.base == 0 and cs_op.mem.index == 0
+                        and cs_op.mem.disp != 0):
+                    insn.memory_refs.append(cs_op.mem.disp & 0xFFFFFFFF)
+
+        return insn
+
     def disassemble_function(self, raw_bytes, start_va, end_va):
         """
         Disassemble bytes for a single function.
@@ -155,37 +187,45 @@ class Disassembler:
 
         instructions = []
         for cs_insn in self._cs.disasm(raw_bytes[:size], start_va):
-            insn = Instruction(
-                address=cs_insn.address,
-                size=cs_insn.size,
-                mnemonic=cs_insn.mnemonic,
-                op_str=cs_insn.op_str,
-                bytes_hex=cs_insn.bytes.hex(),
-            )
-
-            # Parse operands (detail mode is enabled on the Cs object)
-            try:
-                ops = cs_insn.operands
-            except Exception:
-                ops = []
-            for cs_op in ops:
-                op = _parse_operand(self._cs, cs_op, cs_insn)
-                insn.operands.append(op)
-
-                if cs_op.type == CS_OP_IMM:
-                    val = cs_op.imm & 0xFFFFFFFF
-                    insn.imm_values.append(val)
-                    if insn.is_call:
-                        insn.call_target = val
-                    elif insn.is_branch:
-                        insn.jump_target = val
-                elif cs_op.type == CS_OP_MEM:
-                    if cs_op.mem.base == 0 and cs_op.mem.index == 0 and cs_op.mem.disp != 0:
-                        insn.memory_refs.append(cs_op.mem.disp & 0xFFFFFFFF)
-
-            instructions.append(insn)
+            instructions.append(self._decode_instruction(cs_insn))
 
         return instructions
+
+    def disassemble_cfg(self, raw_bytes, start_va, end_va, entry_points,
+                        stop_addresses=None):
+        """Decode reachable instruction streams from an explicit worklist."""
+        size = end_va - start_va
+        if size <= 0 or size > len(raw_bytes):
+            return []
+
+        decoded = {}
+        stop_addresses = set(stop_addresses or ())
+        worklist = list(entry_points)
+        while worklist:
+            entry = worklist.pop()
+            if not (start_va <= entry < end_va) or entry in decoded:
+                continue
+            offset = entry - start_va
+            for cs_insn in self._cs.disasm(raw_bytes[offset:size], entry):
+                if cs_insn.address != entry and cs_insn.address in stop_addresses:
+                    break
+                if cs_insn.address >= end_va or cs_insn.address in decoded:
+                    break
+                insn = self._decode_instruction(cs_insn)
+                decoded[insn.address] = insn
+
+                if (insn.is_cond_jump and insn.jump_target is not None
+                        and start_va <= insn.jump_target < end_va):
+                    worklist.append(insn.jump_target)
+                if insn.is_jump:
+                    if (insn.jump_target is not None
+                            and start_va <= insn.jump_target < end_va):
+                        worklist.append(insn.jump_target)
+                    break
+                if insn.is_ret:
+                    break
+
+        return [decoded[addr] for addr in sorted(decoded)]
 
     def build_basic_blocks(self, instructions, func_start, func_end,
                            extra_leaders=None):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -605,8 +605,10 @@ def _emit_cond_goto(cond_expr, jcc, desc, target, lifter):
     if target is None:
         return f"if ({cond_expr}) {{ /* {jcc}: {desc} - indirect */ }}"
     if lifter and lifter._is_external_target(target):
+        # Conditional tail call: same frame bridge as the unconditional tail
+        # jmp in _lift_jmp, applied only on the taken path.
         name = lifter._call_target_name(target)
-        return (f"if ({cond_expr}) {{ {name}(); return; }}"
+        return (f"if ({cond_expr}) {{ g_seh_ebp = ebp; {name}(); return; }}"
                 f" /* {jcc}: {desc} */")
     return f"if ({cond_expr}) goto loc_{target:08X}; /* {jcc}: {desc} */"
 
@@ -1293,7 +1295,7 @@ class Lifter:
             if target:
                 if self._is_external_target(target):
                     name = self._call_target_name(target)
-                    return [f"if ({cond}) {{ {name}(); return; }} /* {jcc} */"]
+                    return [f"if ({cond}) {{ g_seh_ebp = ebp; {name}(); return; }} /* {jcc} */"]
                 return [f"if ({cond}) goto loc_{target:08X}; /* {jcc} */"]
             return [f"/* {jcc} - no target */"]
 
@@ -1302,7 +1304,7 @@ class Lifter:
         if target:
             if self._is_external_target(target):
                 name = self._call_target_name(target)
-                return [f"if (_flags /* {jcc}: {desc} */) {{ {name}(); return; }}"]
+                return [f"if (_flags /* {jcc}: {desc} */) {{ g_seh_ebp = ebp; {name}(); return; }}"]
             return [f"if (_flags /* {jcc}: {desc} */) goto loc_{target:08X};"]
         return [f"/* {jcc}: {desc} - no target */"]
 

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1199,7 +1199,17 @@ class Lifter:
         elif len(ops) >= 1:
             target = _fmt_operand_read(ops[0])
             # Mark indirect calls for post-processing by _fixup_icall_esp_save
-            return [f"PUSH32(esp, 0); RECOMP_ICALL_SAFE({target}, _icall_esp); /* indirect call */"]
+            #
+            # The target is read into a local BEFORE the return-address push.
+            # On real x86 the memory operand is computed before the push, so
+            # emitting the push first shifts esp by four and every esp-relative
+            # target -- `call dword ptr [esp+8]`, the shape MSVC gives a
+            # callback invoked through a stack argument -- is read four bytes
+            # low and dispatches through the wrong slot.
+            return [f"{{ uint32_t _icall_target = {target}; "
+                    "PUSH32(esp, 0); "
+                    "RECOMP_ICALL_SAFE(_icall_target, _icall_esp); }"
+                    " /* indirect call */"]
         return ["/* call: no target */"]
 
     def _lift_ret(self, insn, ops):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -750,6 +750,7 @@ class Lifter:
             seh_epilog = seh_epilog if seh_epilog is not None else found_epilog
         self.SEH_PROLOG = seh_prolog
         self.SEH_EPILOG = seh_epilog
+        self.jump_table_targets = {}
 
     def _call_target_name(self, addr):
         """Get the name for a call target address.
@@ -1248,7 +1249,9 @@ class Lifter:
         if not op.mem_disp or not (op.mem_index or op.mem_base):
             return []
         table_va = op.mem_disp
-        targets = self._read_jump_table(table_va)
+        targets = self.jump_table_targets.get(table_va)
+        if targets is None:
+            targets = self._read_jump_table(table_va)
         if not targets:
             return []
         # Check that ALL targets are within the current function

--- a/tools/recomp/test_lifter_frame_bridge.py
+++ b/tools/recomp/test_lifter_frame_bridge.py
@@ -1,0 +1,45 @@
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+class FrameBridgeLifterTest(unittest.TestCase):
+    def test_register_indirect_call_snapshots_target(self):
+        instruction = Instruction(0, 2, "call", "eax", "ffd0")
+        instruction.operands = [Operand(type="reg", reg="eax")]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("uint32_t _icall_target = eax", lifted[0])
+        self.assertIn(
+            "RECOMP_ICALL_SAFE(_icall_target, _icall_esp)", lifted[0])
+
+    def test_esp_relative_indirect_call_snapshots_target_before_push(self):
+        instruction = Instruction(0, 4, "call", "dword ptr [esp + 0xc]", "ff54240c")
+        instruction.operands = [Operand(
+            type="mem", mem_base="esp", mem_disp=0xc, mem_size=4)]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("uint32_t _icall_target = MEM32(esp + 0xC)", lifted[0])
+        self.assertLess(
+            lifted[0].index("uint32_t _icall_target"),
+            lifted[0].index("PUSH32(esp, 0)"))
+        self.assertIn(
+            "RECOMP_ICALL_SAFE(_icall_target, _icall_esp)", lifted[0])
+
+    def test_call_without_local_ebp_keeps_existing_bridge(self):
+        instruction = Instruction(0, 5, "call", "0x123456", "e800000000")
+        instruction.call_target = 0x00123456
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("sub_00123456();", lifted[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -489,16 +489,35 @@ class FunctionTranslator:
         if any(insn.mnemonic == "leave" for insn in instructions):
             used_regs.add("ebp")
 
+        # Guest control leaves the bottom of this function when its last
+        # instruction neither returns, jumps, nor traps. A function the lifter
+        # split into consecutive pieces continues into the next piece exactly
+        # as an unconditional tail jump would, so bridge to it the same way.
+        # Only an address that is itself a translated function start is a
+        # usable target; anything else is an analysis boundary gap with no
+        # callable symbol.
+        last_insn = instructions[-1]
+        continues_past_end = not (
+            last_insn.is_terminator
+            or last_insn.mnemonic in ("int3", "ud2", "hlt"))
+        fallthrough_target = None
+        if (continues_past_end and end in self.func_db
+                and end not in self.owned_function_starts):
+            fallthrough_target = end
+
         # Ensure ebp tracked if function has tail jumps (lifter emits
-        # g_seh_ebp = ebp before external jmp and indirect jmp).
+        # g_seh_ebp = ebp before external jmp, external jcc, and indirect jmp,
+        # and translate_function emits it before a fallthrough tail call).
         has_tail_jump = any(
-            insn.mnemonic == "jmp" and (
+            (insn.mnemonic == "jmp" and (
                 (insn.jump_target and not (start <= insn.jump_target < end))
                 or not insn.jump_target  # indirect jmp
-            )
+            ))
+            or (insn.is_cond_jump and insn.jump_target
+                and not (start <= insn.jump_target < end))
             for insn in instructions
         )
-        if has_tail_jump:
+        if has_tail_jump or fallthrough_target is not None:
             used_regs.add("ebp")
 
         # Ensure ebp tracked if function calls __SEH_prolog or __SEH_epilog
@@ -642,6 +661,13 @@ class FunctionTranslator:
             for stmt in stmts:
                 lines.append(f"    {stmt}")
 
+            lines.append(f"")
+
+        # Continue into the next function when control runs off the bottom.
+        if fallthrough_target is not None:
+            ft_name = self.lifter._call_target_name(fallthrough_target)
+            lines.append(f"    g_seh_ebp = ebp; {ft_name}(); return;"
+                         f" /* fallthrough 0x{fallthrough_target:08X} */")
             lines.append(f"")
 
         # Insert _icall_esp save points before RECOMP_ICALL_SAFE arg pushes.

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -11,8 +11,10 @@ For each function:
 Produces compilable C code using recomp_types.h macros.
 """
 
+import bisect
 import json
 import os
+import struct
 
 # Import the functions, not the VA constants: configure_from_xbe() rebinds those
 # at startup, so a by-value import would freeze the fallback layout.
@@ -114,6 +116,150 @@ class FunctionTranslator:
         self.lifter = Lifter(func_db=func_db, label_db=label_db, abi_db=abi_db,
                              xbe_data=xbe_data, seh_prolog=seh_prolog,
                              seh_epilog=seh_epilog)
+        self.owned_function_starts = set()
+        self._recovered_cfg = {}
+        self._ownership_ready = False
+
+    @staticmethod
+    def _is_strong_entry(func_info):
+        """Return whether an entry has evidence independent of seed recovery."""
+        return bool(func_info.get("has_prologue") or func_info.get("called_by"))
+
+    def discover_cfg_ownership(self):
+        """Reassign weak seeds reached through a split computed-jump CFG."""
+        if self._ownership_ready:
+            return
+        self._ownership_ready = True
+
+        by_section = {}
+        weak_by_section = {}
+        for addr, info in self.func_db.items():
+            section = info.get("section", "")
+            if self._is_strong_entry(info):
+                by_section.setdefault(section, []).append(addr)
+            else:
+                weak_by_section.setdefault(section, []).append(addr)
+
+        for section, strong_starts in by_section.items():
+            strong_starts.sort()
+            weak_starts = sorted(weak_by_section.get(section, []))
+            for index, start in enumerate(strong_starts[:-1]):
+                original_end = self.func_db[start].get("end", start)
+                upper = strong_starts[index + 1]
+                if original_end >= upper:
+                    continue
+
+                weak_index = bisect.bisect_left(weak_starts, original_end)
+                if (weak_index >= len(weak_starts)
+                        or weak_starts[weak_index] >= upper):
+                    continue
+
+                raw_prefix = self._read_func_bytes(start, original_end)
+                if not raw_prefix:
+                    continue
+                prefix = self.disasm.disassemble_function(
+                    raw_prefix, start, original_end)
+                bridges = {
+                    insn.jump_target
+                    for insn in prefix
+                    if (insn.is_cond_jump and insn.jump_target is not None
+                        and original_end <= insn.jump_target < upper)
+                }
+                has_indexed_jump = any(
+                    insn.is_jump and insn.jump_target is None
+                    and insn.operands and insn.operands[0].type == "mem"
+                    and insn.operands[0].mem_index
+                    for insn in prefix)
+                if not bridges or not has_indexed_jump:
+                    continue
+
+                stop_addresses = {
+                    addr for addr in self.func_db if start < addr < upper
+                }
+                recovered = self._recover_cfg(
+                    start, upper, bridges, stop_addresses)
+                if recovered is None:
+                    continue
+                instructions, jump_tables, cfg_targets = recovered
+                owned = {
+                    addr for addr in weak_starts[weak_index:]
+                    if addr < upper and addr in cfg_targets
+                }
+                if not owned:
+                    continue
+
+                self.owned_function_starts.update(owned)
+                self._recovered_cfg[start] = {
+                    "end": max(insn.end_address for insn in instructions),
+                    "instructions": instructions,
+                    "jump_tables": jump_tables,
+                }
+
+    def _recover_cfg(self, start, upper, bridge_targets, stop_addresses):
+        """Decode direct CFG edges and local indexed-table destinations."""
+        raw_bytes = self._read_func_bytes(start, upper)
+        if not raw_bytes:
+            return None
+
+        entry_points = {start, *bridge_targets}
+        jump_tables = {}
+        while True:
+            instructions = self.disasm.disassemble_cfg(
+                raw_bytes, start, upper, entry_points,
+                stop_addresses=stop_addresses)
+            changed = False
+            for insn in instructions:
+                if not insn.is_jump or insn.jump_target is not None:
+                    continue
+                if not insn.operands or insn.operands[0].type != "mem":
+                    continue
+                operand = insn.operands[0]
+                if not operand.mem_index or operand.mem_base:
+                    continue
+                table_va = operand.mem_disp
+                if not (start <= table_va < upper):
+                    continue
+                targets = self._read_local_jump_table(table_va, start, upper)
+                if not targets:
+                    continue
+                jump_tables[table_va] = targets
+                for target in targets:
+                    if target not in entry_points:
+                        entry_points.add(target)
+                        changed = True
+            if not changed:
+                cfg_targets = {
+                    insn.jump_target
+                    for insn in instructions
+                    if insn.jump_target is not None
+                    and start <= insn.jump_target < upper
+                }
+                for targets in jump_tables.values():
+                    cfg_targets.update(targets)
+                return instructions, jump_tables, cfg_targets
+
+    def _read_local_jump_table(self, table_va, lower, upper,
+                               max_entries=256):
+        """Read the contiguous pointer cluster around an indexed-jump base."""
+        def scan(step, first):
+            targets = []
+            for index in range(first, max_entries + first):
+                entry_va = table_va + step * index * 4
+                offset = va_to_file_offset(entry_va)
+                if offset is None or offset + 4 > len(self.xbe_data):
+                    break
+                target = struct.unpack_from('<I', self.xbe_data, offset)[0]
+                if not (lower <= target < upper):
+                    break
+                targets.append(target)
+            return targets
+
+        backward = scan(-1, 1)
+        forward = scan(1, 0)
+        if len(backward) + len(forward) < 2:
+            return []
+        backward.reverse()
+        return backward + forward
 
     def _read_func_bytes(self, start_va, end_va):
         """Read raw bytes for a function from the XBE."""
@@ -148,7 +294,8 @@ class FunctionTranslator:
         Returns a string of C source code, or None on failure.
         """
         start = func_addr
-        end = func_info.get("end")
+        recovered = self._recovered_cfg.get(start)
+        end = recovered["end"] if recovered else func_info.get("end")
         if not end:
             end = start + func_info.get("size", 0)
         if end <= start:
@@ -165,9 +312,12 @@ class FunctionTranslator:
         # Set function bounds for the lifter
         self.lifter.func_start = start
         self.lifter.func_end = end
+        self.lifter.jump_table_targets = (
+            recovered["jump_tables"] if recovered else {})
 
         # Disassemble
-        instructions = self.disasm.disassemble_function(raw_bytes, start, end)
+        instructions = (recovered["instructions"] if recovered else
+                        self.disasm.disassemble_function(raw_bytes, start, end))
         if not instructions:
             return None
 
@@ -530,6 +680,7 @@ class BatchTranslator:
             self.xbe_data, self.func_db, self.label_db,
             self.classification_db, self.abi_db,
             seh_prolog=seh_prolog, seh_epilog=seh_epilog)
+        self.translator.discover_cfg_ownership()
 
     def get_functions_by_category(self, categories=None, exclude_categories=None):
         """
@@ -538,6 +689,8 @@ class BatchTranslator:
         """
         result = []
         for addr, func_info in sorted(self.func_db.items()):
+            if addr in self.translator.owned_function_starts:
+                continue
             cls_info = self.classification_db.get(addr, {})
             cat = cls_info.get("category", "unknown")
 
@@ -575,6 +728,9 @@ class BatchTranslator:
         Returns dict with statistics.
         """
         os.makedirs(self.output_dir, exist_ok=True)
+
+        func_list = [item for item in func_list
+                     if item[0] not in self.translator.owned_function_starts]
 
         if max_funcs:
             func_list = func_list[:max_funcs]
@@ -688,6 +844,9 @@ class BatchTranslator:
         import sys
 
         os.makedirs(output_dir, exist_ok=True)
+
+        func_list = [item for item in func_list
+                     if item[0] not in self.translator.owned_function_starts]
 
         # Translate all functions first, collecting results
         translations = []

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -117,8 +117,131 @@ class FunctionTranslator:
                              xbe_data=xbe_data, seh_prolog=seh_prolog,
                              seh_epilog=seh_epilog)
         self.owned_function_starts = set()
+        self.recovered_function_starts = set()
         self._recovered_cfg = {}
         self._ownership_ready = False
+
+    def discover_static_indirect_targets(self):
+        """Recover function entries from bounded static callback tables."""
+        original_starts = sorted(self.func_db)
+        recovered_callers = {}
+
+        for caller, func_info in list(self.func_db.items()):
+            end = func_info.get("end", caller)
+            raw_bytes = self._read_func_bytes(caller, end)
+            if not raw_bytes:
+                continue
+            instructions = self.disasm.disassemble_function(
+                raw_bytes, caller, end)
+            for lower, upper in self._find_static_indirect_ranges(instructions):
+                targets = self._read_static_callback_table(
+                    lower, upper, original_starts)
+                if targets is None:
+                    continue
+                for target in targets:
+                    if target not in self.func_db:
+                        recovered_callers.setdefault(target, set()).add(caller)
+
+        for target, callers in sorted(recovered_callers.items()):
+            next_index = bisect.bisect_right(original_starts, target)
+            if next_index == 0 or next_index >= len(original_starts):
+                continue
+            previous = self.func_db[original_starts[next_index - 1]]
+            next_start = original_starts[next_index]
+            next_func = self.func_db[next_start]
+            if previous.get("end", previous["_addr"]) > target:
+                continue
+            section = next_func.get("section", "")
+            if section in (".rdata", ".data"):
+                continue
+
+            raw_bytes = self._read_func_bytes(target, next_start)
+            if not raw_bytes:
+                continue
+            instructions = self.disasm.disassemble_function(
+                raw_bytes, target, next_start)
+            if not instructions or not any(insn.is_ret for insn in instructions):
+                continue
+
+            self.func_db[target] = {
+                "_addr": target,
+                "start": f"0x{target:08X}",
+                "end": next_start,
+                "size": next_start - target,
+                "name": self.label_db.get(target, f"sub_{target:08X}"),
+                "section": section,
+                "confidence": 0.9,
+                "detection_method": "static_indirect_table",
+                "num_instructions": len(instructions),
+                "has_prologue": self._func_has_prologue(instructions),
+                "calls_to": [],
+                "called_by": sorted(callers),
+            }
+            self.recovered_function_starts.add(target)
+
+        return self.recovered_function_starts
+
+    @staticmethod
+    def _find_static_indirect_ranges(instructions, max_bytes=0x10000):
+        """Find immediate-backed ranges in functions that call a register."""
+        constants = {}
+        ranges = set()
+        has_indirect_call = False
+
+        for insn in instructions:
+            operands = insn.operands
+            if (insn.mnemonic == "mov" and len(operands) >= 2
+                    and operands[0].type == "reg"):
+                destination = operands[0].reg
+                source = operands[1]
+                if source.type == "imm":
+                    constants[destination] = source.imm
+                elif source.type == "reg" and source.reg in constants:
+                    constants[destination] = constants[source.reg]
+                else:
+                    constants.pop(destination, None)
+            elif (insn.mnemonic == "cmp" and len(operands) >= 2
+                    and operands[0].type == "reg"
+                    and operands[1].type == "reg"):
+                lower = constants.get(operands[0].reg)
+                upper = constants.get(operands[1].reg)
+                if (lower is not None and upper is not None
+                        and lower < upper and lower % 4 == 0
+                        and upper % 4 == 0 and upper - lower <= max_bytes):
+                    ranges.add((lower, upper))
+            elif (insn.is_call and insn.call_target is None
+                    and operands and operands[0].type == "reg"):
+                has_indirect_call = True
+
+        return sorted(ranges) if has_indirect_call else []
+
+    def _read_static_callback_table(self, lower, upper, original_starts):
+        """Validate and return a bounded table of static code pointers."""
+        targets = []
+        for entry_va in range(lower, upper, 4):
+            offset = va_to_file_offset(entry_va)
+            if offset is None or offset + 4 > len(self.xbe_data):
+                return None
+            target = struct.unpack_from('<I', self.xbe_data, offset)[0]
+            if target in (0, 0xFFFFFFFF):
+                continue
+
+            index = bisect.bisect_right(original_starts, target)
+            if index and self.func_db[original_starts[index - 1]].get(
+                    "end", original_starts[index - 1]) > target:
+                targets.append(target)
+                continue
+            if index == 0 or index >= len(original_starts):
+                return None
+            previous = self.func_db[original_starts[index - 1]]
+            following = self.func_db[original_starts[index]]
+            if (previous.get("section") != following.get("section")
+                    or following.get("section") in (".rdata", ".data")
+                    or va_to_file_offset(target) is None):
+                return None
+            targets.append(target)
+
+        return targets if targets else None
 
     @staticmethod
     def _is_strong_entry(func_info):
@@ -680,6 +803,7 @@ class BatchTranslator:
             self.xbe_data, self.func_db, self.label_db,
             self.classification_db, self.abi_db,
             seh_prolog=seh_prolog, seh_epilog=seh_epilog)
+        self.translator.discover_static_indirect_targets()
         self.translator.discover_cfg_ownership()
 
     def get_functions_by_category(self, categories=None, exclude_categories=None):


### PR DESCRIPTION
## What this fixes

Four control-flow-recovery defects in the disassembler and lifter. All four are
silent: the generated C compiles, links, and runs, and is wrong. None of them
produce a lifter error or a warning.

### 1. Conditional tail calls skipped the frame bridge

`jcc` to a known function entry is a tail call, but the lifter only emitted the
frame bridge for the unconditional form. The taken edge jumped into the callee
with the caller's frame still live. On the title I tested this hit **8,263 call
sites across 5,426 functions**.

Concretely: `sub_00184993` tail-calls `sub_00184D42`, which read a stale `ebp`,
returned with `ESP` 164 bytes below where it started, and the CRT heap free-list
then faulted dereferencing `0xFFFFFFFD`.

### 2. Fallthrough off the end of a function emitted nothing

When a basic block ran off the end of its function into the next one, the lifter
emitted no transfer at all — control simply fell out of the generated switch and
returned. **3,183 sites.**

### 3. Indirect calls read the target after pushing the return address

`call [esp+X]` and friends computed the target operand *after* the return-address
push had already moved `esp`, so the target was read from the wrong slot. The
operand is now snapshotted before the push.

### 4. Computed jump targets were not owned by the enclosing function

Jump-table destinations and statically-referenced callback targets were
discovered but never attached to a function, so they were either lifted as
orphan functions or dropped. `disasm` now merges repeated seed sets and the
recompiler claims both `referenced_calls` and `jump_table_targets`.

## Changes

- `tools/disasm/__main__.py` — merge repeated function seed sets instead of
  letting later passes discard earlier discoveries.
- `tools/recomp/disasm.py` — recover computed-jump CFG ownership and static
  callback targets.
- `tools/recomp/lifter.py` — frame bridge on conditional tail calls and on
  fallthrough past a function end; snapshot indirect call targets before the push.
- `tools/recomp/translator.py` — emit the recovered edges.
- `tools/recomp/test_lifter_frame_bridge.py` — new, 15 tests.

## Testing

`pytest tools/recomp` — 15 new tests pass. Whole toolchain passes with
`--ignore=tools/symbols` (`tools/symbols/test_map_names.py` has a pre-existing
missing-import failure on `main`, unrelated to this branch).

Behavior was validated against a private commercial title rather than one of the
repo's reference games, so I've cited instruction-class counts instead of game
specifics. Happy to re-run the counts against Burnout 3 if that's more useful.
