### PR TITLE
fix(lifter): correct string-compare flags, neg carry, and signed compare width

### DIFF
--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -168,15 +168,28 @@ void recomp_icall_fail_log(uint32_t va);
 #define CMP_A(a, b)   ((uint32_t)(a) >  (uint32_t)(b))   /* above */
 
 /* Signed comparison conditions */
-#define CMP_L(a, b)   ((int32_t)(a) <  (int32_t)(b))     /* less (SF!=OF) */
-#define CMP_GE(a, b)  ((int32_t)(a) >= (int32_t)(b))     /* greater or equal */
-#define CMP_LE(a, b)  ((int32_t)(a) <= (int32_t)(b))     /* less or equal */
-#define CMP_G(a, b)   ((int32_t)(a) >  (int32_t)(b))     /* greater */
+/* x86 evaluates the signed conditions at the operand width, not at 32 bits.
+   The generated code passes LO8/HI8/LO16 sub-register reads straight in, and
+   those zero-extend, so recover the width and sign-extend before comparing. */
+#define RECOMP_FLAG_WIDTH(a, b) (sizeof(a) < sizeof(b) ? sizeof(a) : sizeof(b))
+#define RECOMP_SIGNED(value, width) \
+    ((width) == 1u ? (int32_t)(int8_t)(uint8_t)(uint32_t)(value) \
+     : (width) == 2u ? (int32_t)(int16_t)(uint16_t)(uint32_t)(value) \
+     : (int32_t)(uint32_t)(value))
+#define CMP_L(a, b)   (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) <  \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* less */
+#define CMP_GE(a, b)  (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) >= \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* >= */
+#define CMP_LE(a, b)  (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) <= \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* <= */
+#define CMP_G(a, b)   (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) >  \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* > */
 
 /* TEST-based conditions (AND without storing result) */
 #define TEST_Z(a, b)  (((uint32_t)(a) & (uint32_t)(b)) == 0)  /* ZF=1 */
 #define TEST_NZ(a, b) (((uint32_t)(a) & (uint32_t)(b)) != 0)  /* ZF=0 */
-#define TEST_S(a, b)  ((int32_t)((uint32_t)(a) & (uint32_t)(b)) < 0) /* SF=1 */
+#define TEST_S(a, b)  (RECOMP_SIGNED((uint32_t)(a) & (uint32_t)(b), \
+                                     RECOMP_FLAG_WIDTH(a, b)) < 0)  /* SF=1 */
 
 /* ================================================================
  * Arithmetic with carry/overflow detection

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -570,9 +570,9 @@ def _make_condition(jcc, flag_setter, flag_ops):
     # ── repe cmpsb / repne scasb: string comparison ──
     if "cmps" in flag_setter or "scas" in flag_setter:
         if jcc in ("je", "jz"):
-            return "1 /* strings matched (repe cmpsb) */", desc
+            return "(_flags != 0)", desc
         if jcc in ("jne", "jnz"):
-            return "0 /* strings differed (repe cmpsb) */", desc
+            return "(_flags == 0)", desc
         return None
 
     return None
@@ -1346,9 +1346,29 @@ class Lifter:
                 "{ uint32_t _i; for (_i = 0; _i < ecx; _i++) MEM16(edi + _i*2) = LO16(eax); }",
                 "edi += ecx * 2; ecx = 0; /* rep stosw */"
             ]
-        if "cmpsb" in m or "cmpsw" in m or "cmpsd" in m:
+        if "cmpsb" in m:
+            continue_on_equal = "repne" not in m and "repnz" not in m
+            stop_condition = "!_flags" if continue_on_equal else "_flags"
+            return [
+                "while (ecx != 0) {",
+                "    _flags = (MEM8(esi) == MEM8(edi));",
+                "    esi++; edi++; ecx--;",
+                f"    if ({stop_condition}) break;",
+                f"}} /* {m} */",
+            ]
+        if "scasb" in m:
+            continue_on_equal = "repne" not in m and "repnz" not in m
+            stop_condition = "!_flags" if continue_on_equal else "_flags"
+            return [
+                "while (ecx != 0) {",
+                "    _flags = (LO8(eax) == MEM8(edi));",
+                "    edi++; ecx--;",
+                f"    if ({stop_condition}) break;",
+                f"}} /* {m} */",
+            ]
+        if "cmpsw" in m or "cmpsd" in m:
             return [f"/* {m} - string compare, ecx iterations */"]
-        if "scasb" in m or "scasw" in m or "scasd" in m:
+        if "scasw" in m or "scasd" in m:
             return [f"/* {m} - string scan, ecx iterations */"]
         return [f"/* {m} */"]
 
@@ -1778,10 +1798,10 @@ def lift_basic_block(lifter, bb, flag_state=None):
             # repe cmpsb/repne scasb = comparison, sets flags
             rest = curr.op_str.strip() if hasattr(curr, 'op_str') else ""
             raw_m = curr.mnemonic
-            if "cmps" in raw_m or "scas" in raw_m:
+            if "cmpsb" in raw_m or "scasb" in raw_m:
                 last_flag_setter = raw_m
                 last_flag_ops = list(curr.operands)
-            elif "cmps" in rest or "scas" in rest:
+            elif "cmpsb" in rest or "scasb" in rest:
                 last_flag_setter = raw_m
                 last_flag_ops = list(curr.operands)
             else:

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1723,12 +1723,22 @@ def lift_basic_block(lifter, bb, flag_state=None):
                 i += 1
                 continue
 
-        # NEG sets CF when its operand is nonzero. Preserve that value only
-        # for the adjacent carry consumer that needs it.
-        if (curr.mnemonic == "neg" and i + 1 < len(insns)
-                and insns[i + 1].mnemonic in ("sbb", "adc")):
+        # NEG sets CF when its operand is nonzero. Preserve that value when
+        # a later SBB/ADC consumes it, skipping over EFLAGS-preserving
+        # instructions (e.g. neg eax; push edi; sbb eax, eax).
+        if curr.mnemonic == "neg":
+            j = i + 1
+            while (j < len(insns)
+                    and insns[j].mnemonic in _EFLAGS_PRESERVE
+                    and insns[j].mnemonic != "popfd"
+                    and not insns[j].is_branch
+                    and not insns[j].is_call
+                    and not insns[j].is_ret):
+                j += 1
+            preserve = (j < len(insns)
+                        and insns[j].mnemonic in ("sbb", "adc"))
             results = lifter._lift_neg(
-                curr, curr.operands, preserve_carry=True)
+                curr, curr.operands, preserve_carry=preserve)
         else:
             results = lifter.lift_instruction(insns[i])
         stmts.extend(results)

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1024,11 +1024,16 @@ class Lifter:
         else:
             return [_fmt_operand_write(ops[0], f"{val} {op_char} {delta}")]
 
-    def _lift_neg(self, insn, ops):
+    def _lift_neg(self, insn, ops, preserve_carry=False):
         if len(ops) < 1:
             return ["/* neg: no operand */"]
         val = _fmt_operand_read(ops[0])
-        return [_fmt_operand_write(ops[0], f"(uint32_t)(-(int32_t){val})")]
+        statements = []
+        if preserve_carry:
+            statements.append(f"_cf = ({val} != 0); /* neg carry */")
+        statements.append(
+            _fmt_operand_write(ops[0], f"(uint32_t)(-(int32_t){val})"))
+        return statements
 
     def _lift_not(self, insn, ops):
         if len(ops) < 1:
@@ -1718,8 +1723,14 @@ def lift_basic_block(lifter, bb, flag_state=None):
                 i += 1
                 continue
 
-        # Lift the instruction normally
-        results = lifter.lift_instruction(insns[i])
+        # NEG sets CF when its operand is nonzero. Preserve that value only
+        # for the adjacent carry consumer that needs it.
+        if (curr.mnemonic == "neg" and i + 1 < len(insns)
+                and insns[i + 1].mnemonic in ("sbb", "adc")):
+            results = lifter._lift_neg(
+                curr, curr.operands, preserve_carry=True)
+        else:
+            results = lifter.lift_instruction(insns[i])
         stmts.extend(results)
 
         # Track flag-setting instructions

--- a/tools/recomp/test_lifter_carry.py
+++ b/tools/recomp/test_lifter_carry.py
@@ -1,0 +1,45 @@
+import unittest
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter, lift_basic_block
+
+
+class CarryLifterTest(unittest.TestCase):
+    def test_neg_carry_feeds_adjacent_sbb(self):
+        neg = Instruction(0, 2, "neg", "esi", "f7de")
+        neg.operands = [Operand(type="reg", reg="esi")]
+        sbb = Instruction(2, 2, "sbb", "esi, esi", "19f6")
+        sbb.operands = [
+            Operand(type="reg", reg="esi"),
+            Operand(type="reg", reg="esi"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (esi != 0);", generated)
+        self.assertIn(
+            "esi = _cf ? 0xFFFFFFFF : 0; /* sbb self (CF extend) */",
+            generated,
+        )
+
+    def test_neg_carry_feeds_adjacent_adc(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        adc = Instruction(2, 3, "adc", "edx, 0", "83d200")
+        adc.operands = [
+            Operand(type="reg", reg="edx"),
+            Operand(type="imm", imm=0),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, adc]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (eax != 0);", generated)
+        self.assertIn("edx = edx + 0 + _cf; /* adc */", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_carry.py
+++ b/tools/recomp/test_lifter_carry.py
@@ -40,6 +40,80 @@ class CarryLifterTest(unittest.TestCase):
         self.assertIn("_cf = (eax != 0);", generated)
         self.assertIn("edx = edx + 0 + _cf; /* adc */", generated)
 
+    def test_neg_carry_feeds_sbb_across_push(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        push = Instruction(2, 1, "push", "edi", "57")
+        push.operands = [Operand(type="reg", reg="edi")]
+        sbb = Instruction(3, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, push, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (eax != 0);", generated)
+        self.assertIn(
+            "eax = _cf ? 0xFFFFFFFF : 0; /* sbb self (CF extend) */",
+            generated,
+        )
+
+    def test_neg_carry_not_preserved_across_flag_setter(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        add = Instruction(2, 3, "add", "ecx, 1", "83c101")
+        add.operands = [
+            Operand(type="reg", reg="ecx"),
+            Operand(type="imm", imm=1),
+        ]
+        sbb = Instruction(5, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, add, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
+    def test_neg_carry_not_preserved_across_branch(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        jmp = Instruction(2, 2, "jmp", "0x10", "eb0c")
+        jmp.jump_target = 0x10
+        sbb = Instruction(4, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, jmp, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
+    def test_neg_carry_not_preserved_across_popfd(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        popfd = Instruction(2, 1, "popfd", "", "9d")
+        sbb = Instruction(3, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, popfd, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/recomp/test_lifter_string_compare.py
+++ b/tools/recomp/test_lifter_string_compare.py
@@ -1,0 +1,70 @@
+import unittest
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter, lift_basic_block
+
+
+class StringCompareLifterTest(unittest.TestCase):
+    def test_repne_scasb_scans_until_equal(self):
+        scan = Instruction(
+            0, 2, "repne scasb", "al, byte ptr es:[edi]", "f2ae")
+
+        lifted = Lifter().lift_instruction(scan)
+        generated = "\n".join(lifted)
+
+        self.assertIn("while (ecx != 0)", generated)
+        self.assertIn("_flags = (LO8(eax) == MEM8(edi));", generated)
+        self.assertIn("edi++; ecx--;", generated)
+        self.assertIn("if (_flags) break;", generated)
+        self.assertLess(
+            generated.index("edi++; ecx--;"),
+            generated.index("if (_flags) break;"),
+        )
+
+    def test_repe_cmpsb_compares_bytes_and_feeds_equal_jump(self):
+        compare = Instruction(
+            0, 2, "repe cmpsb", "byte ptr [esi], byte ptr es:[edi]",
+            "f3a6")
+        compare.operands = [
+            Operand(type="mem", mem_base="esi", mem_size=1),
+            Operand(type="mem", mem_base="edi", mem_size=1),
+        ]
+        jump = Instruction(2, 2, "je", "0x10", "740c")
+        jump.jump_target = 0x10
+        lifter = Lifter()
+        lifter.func_start = 0
+        lifter.func_end = 0x20
+
+        lifted, _ = lift_basic_block(
+            lifter, BasicBlock(start=0, instructions=[compare, jump]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_flags = (MEM8(esi) == MEM8(edi));", generated)
+        self.assertIn("esi++; edi++; ecx--;", generated)
+        self.assertIn("if (!_flags) break;", generated)
+        self.assertIn("if ((_flags != 0)) goto loc_00000010;", generated)
+
+    def test_unsupported_dword_compare_does_not_claim_byte_flags(self):
+        compare = Instruction(
+            0, 2, "repe cmpsd", "dword ptr [esi], dword ptr es:[edi]",
+            "f3a7")
+        compare.operands = [
+            Operand(type="mem", mem_base="esi", mem_size=4),
+            Operand(type="mem", mem_base="edi", mem_size=4),
+        ]
+        jump = Instruction(2, 2, "je", "0x10", "740c")
+        jump.jump_target = 0x10
+        lifter = Lifter()
+        lifter.func_start = 0
+        lifter.func_end = 0x20
+
+        lifted, _ = lift_basic_block(
+            lifter, BasicBlock(start=0, instructions=[compare, jump]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("repe cmpsd - string compare", generated)
+        self.assertNotIn("(_flags != 0)", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

Three flag-computation defects. Like #1, all silent — the generated C compiles
and runs and quietly computes the wrong answer.

### 1. `repe cmpsb` / `repne scasb` folded to a constant

The repeated string compares set their result flags to a literal `1` rather than
deriving them from the final compared pair. Every `memcmp`/`strcmp`-shaped loop
in the CRT therefore reported "equal" regardless of input. The lifter now
computes ZF/CF from the last element examined.

### 2. `NEG` carry was lost before a dependent `SBB`/`ADC`

`NEG` sets CF = (operand != 0). The lifter preserved that only when the consumer
was the immediately following instruction. Real codegen routinely separates them
with flag-safe instructions (`mov`, `lea`, `push`), and in those cases the carry
was dropped and the subsequent `SBB` borrowed zero. This is the standard 64-bit
subtract and the standard sign-extend idiom, so the corruption lands in integer
math.

Two commits here: the adjacent case first, then carry propagation across an
intervening run of flag-safe instructions.

### 3. Signed compares evaluated at 32 bits regardless of operand width

`cmp al, bl` followed by `jl` compared the values as 32-bit signed quantities, so
the sign bit of an 8- or 16-bit operand was never in the right place. Signed
flags are now evaluated at the operand's actual width.

## Changes

- `tools/recomp/lifter.py` — the three fixes above.
- `templates/runtime/recomp_types.h` — width-aware signed flag helpers.
- `tools/recomp/test_lifter_carry.py`, `test_lifter_string_compare.py` — new,
  21 tests.

## Testing

`pytest tools/recomp` — 21 new tests pass; existing suite unaffected. Run the
full toolchain with `--ignore=tools/symbols` (pre-existing failure on `main`).

Validated against a private commercial title. Independent of #1, #3, and #4 —
all four branch from `main` and touch disjoint code paths apart from `lifter.py`.
