### PR TITLE
fix(lifter): lift packed SSE and x87 instead of dropping them

### DIFF
--- a/templates/new-game/src/main.c
+++ b/templates/new-game/src/main.c
@@ -55,6 +55,8 @@
 extern uint32_t g_eax, g_ecx, g_edx, g_esp;
 extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
+double g_fp_stack[8];
+uint32_t g_fp_top;
 extern ptrdiff_t g_xbox_mem_offset;
 
 /* ── XBE Constants ─────────────────────────────────────────── */

--- a/templates/new-game/src/main.c
+++ b/templates/new-game/src/main.c
@@ -57,6 +57,9 @@ extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
 double g_fp_stack[8];
 uint32_t g_fp_top;
+/* x87 reset default: all exceptions masked, round to nearest. */
+uint16_t g_fp_control_word = 0x037fu;
+int g_fp_cmp;
 extern ptrdiff_t g_xbox_mem_offset;
 
 /* ── XBE Constants ─────────────────────────────────────────── */

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -102,6 +102,17 @@ extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
 extern double g_fp_stack[8];
 extern uint32_t g_fp_top;
+extern uint16_t g_fp_control_word;
+/* Result of the last x87 compare: -1, 0, or 1. One guest routine can lift
+   to several C functions, so a compare and the FNSTSW that reads it can
+   land in different bodies; the hardware status word is shared too. */
+extern int g_fp_cmp;
+
+/* x86 PF: set when the low byte of the result has an even number of set
+   bits. Used by FNSTSW/TEST AH parity branches. */
+#define PARITY8(value) \
+    ((((0x9669u >> (((uint8_t)(value) ^ ((uint8_t)(value) >> 4)) & 0xfu)) \
+       & 1u)) != 0u)
 
 /* ================================================================
  * ICALL trace ring buffer (for debugging indirect calls)

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -100,6 +100,8 @@ extern uint32_t g_ebx, g_esi, g_edi;
  * Similarly, __SEH_epilog reads g_seh_ebp at entry and writes it at exit.
  */
 extern uint32_t g_seh_ebp;
+extern double g_fp_stack[8];
+extern uint32_t g_fp_top;
 
 /* ================================================================
  * ICALL trace ring buffer (for debugging indirect calls)
@@ -146,6 +148,7 @@ void recomp_icall_fail_log(uint32_t va);
 #define SMEM8(addr)  (*(volatile int8_t   *)XBOX_PTR(addr))
 #define SMEM16(addr) (*(volatile int16_t  *)XBOX_PTR(addr))
 #define SMEM32(addr) (*(volatile int32_t  *)XBOX_PTR(addr))
+#define SMEM64(addr) (*(volatile int64_t  *)XBOX_PTR(addr))
 
 /** Float/double memory access. */
 #define MEMF(addr)   (*(volatile float    *)XBOX_PTR(addr))

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -7,7 +7,7 @@ patterns like cmp+jcc) into C statements using the recomp_types.h macros.
 Register model:
   - eax, ebx, ecx, edx, esi, edi, ebp: uint32_t locals
   - esp: uint32_t local (stack pointer)
-  - FPU: double fp_stack[8] with fp_top index
+  - FPU: shared double g_fp_stack[8] with g_fp_top index
 
 Memory model:
   - MEM8/MEM16/MEM32 macros for memory access at flat addresses
@@ -92,7 +92,23 @@ def _mem_accessor(size):
 
 def _smem_accessor(size):
     """Return the signed MEM macro for a given operand size."""
-    return {1: "SMEM8", 2: "SMEM16", 4: "SMEM32"}.get(size, "SMEM32")
+    return {
+        1: "SMEM8", 2: "SMEM16", 4: "SMEM32", 8: "SMEM64",
+    }.get(size, "SMEM32")
+
+
+def _fmt_fpu_operand(op):
+    """Format an x87 memory or stack-register operand for reading."""
+    if op.type == "mem":
+        accessor = "MEMD" if op.mem_size == 8 else "MEMF"
+        return f"{accessor}({_fmt_mem(op)})"
+    if op.type == "reg":
+        name = op.reg or ""
+        if name == "st":
+            return "fp_st(0)"
+        if name.startswith("st(") and name.endswith(")"):
+            return f"fp_st({name[3:-1]})"
+    return None
 
 
 def _fmt_mem(op):
@@ -1555,15 +1571,18 @@ class Lifter:
                     elif ops[0].mem_size == 8:
                         return [f"fp_push(MEMD({_fmt_mem(ops[0])})); /* fld double */"]
                     return [f"fp_push(MEMF({_fmt_mem(ops[0])})); /* fld */"]
+                source = _fmt_fpu_operand(ops[0])
+                if source is not None:
+                    return [f"fp_push({source}); /* fld {insn.op_str} */"]
             return [f"/* fld {insn.op_str} */"]
 
         if m in ("fst", "fstp"):
-            pop = "p" if m == "fstp" else ""
             if len(ops) >= 1 and ops[0].type == "mem":
+                pop = " fp_pop();" if m == "fstp" else ""
                 if ops[0].mem_size == 4:
-                    return [f"MEMF({_fmt_mem(ops[0])}) = (float)fp_top(); fp_pop{pop}(); /* {m} */"]
+                    return [f"MEMF({_fmt_mem(ops[0])}) = (float)fp_top();{pop} /* {m} */"]
                 elif ops[0].mem_size == 8:
-                    return [f"MEMD({_fmt_mem(ops[0])}) = fp_top(); fp_pop{pop}(); /* {m} */"]
+                    return [f"MEMD({_fmt_mem(ops[0])}) = fp_top();{pop} /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
         if m == "fild":
@@ -1574,23 +1593,44 @@ class Lifter:
 
         if m in ("fist", "fistp"):
             if len(ops) >= 1 and ops[0].type == "mem":
-                mem_acc = _mem_accessor(ops[0].mem_size)
-                return [f"{mem_acc}({_fmt_mem(ops[0])}) = (int32_t)fp_top(); /* {m} */"]
+                size = ops[0].mem_size
+                mem_acc = _smem_accessor(size)
+                int_type = {2: "int16_t", 4: "int32_t", 8: "int64_t"}.get(
+                    size, "int32_t")
+                pop = " fp_pop();" if m == "fistp" else ""
+                return [f"{mem_acc}({_fmt_mem(ops[0])}) = "
+                        f"({int_type})llrint(fp_top());{pop} /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
         if m == "fadd":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() += {source}; /* fadd {insn.op_str} */"]
             return [f"fp_st1() += fp_top(); fp_pop(); /* fadd */"]
         if m == "faddp":
             return [f"fp_st1() += fp_top(); fp_pop(); /* faddp */"]
         if m == "fsub":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() -= {source}; /* fsub {insn.op_str} */"]
             return [f"fp_st1() -= fp_top(); fp_pop(); /* fsub */"]
         if m == "fsubp":
             return [f"fp_st1() -= fp_top(); fp_pop(); /* fsubp */"]
         if m == "fmul":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() *= {source}; /* fmul {insn.op_str} */"]
             return [f"fp_st1() *= fp_top(); fp_pop(); /* fmul */"]
         if m == "fmulp":
             return [f"fp_st1() *= fp_top(); fp_pop(); /* fmulp */"]
         if m == "fdiv":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() /= {source}; /* fdiv {insn.op_str} */"]
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdiv */"]
         if m == "fdivp":
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdivp */"]
@@ -1604,7 +1644,11 @@ class Lifter:
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):
             # Set _fpu_cmp for the fcomp/fnstsw/sahf pattern
-            return [f"_fpu_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
+            source = _fmt_fpu_operand(ops[-1]) if ops else "fp_st1()"
+            pops = 2 if m.endswith("pp") else 1 if m.endswith("p") else 0
+            pop_code = " fp_pop();" * pops
+            return [f"_fpu_cmp = (fp_top() < {source}) ? -1 : "
+                    f"(fp_top() > {source}) ? 1 : 0;{pop_code}"
                     f" /* {m} {insn.op_str} */"]
         if m in ("fcompi", "fcomip", "fucomi", "fucompi", "fucomip", "fcomi"):
             # These set EFLAGS directly (CF, ZF, PF) from FPU comparison

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -336,7 +336,9 @@ def _make_condition(jcc, flag_setter, flag_ops):
     # ── comiss/ucomiss: float comparison, sets CF/ZF/PF ──
     if flag_setter in ("comiss", "comisd", "ucomiss", "ucomisd"):
         def _sse_op(op):
-            if op.type == "reg":
+            if op.type == "reg" and op.reg and op.reg.startswith("xmm"):
+                return f"{op.reg}.f[0]"
+            elif op.type == "reg":
                 return op.reg
             elif op.type == "mem":
                 if op.mem_size == 8:
@@ -914,6 +916,7 @@ class Lifter:
 
         # ── SSE (scalar float) ──
         if m in ("movss", "movsd", "movaps", "movups", "movlps", "movhps",
+                 "movlhps", "movhlps", "movapd", "movupd",
                  "addss", "subss", "mulss", "divss", "sqrtss",
                  "addsd", "subsd", "mulsd", "divsd", "sqrtsd",
                  "minss", "maxss", "minsd", "maxsd",
@@ -921,7 +924,7 @@ class Lifter:
                  "cvtsi2ss", "cvtss2si", "cvttss2si",
                  "cvtsi2sd", "cvtsd2si", "cvttsd2si",
                  "cvtss2sd", "cvtsd2ss",
-                 "xorps", "xorpd", "andps", "orps",
+                 "xorps", "xorpd", "andps", "orps", "andnps",
                  "movd", "movq",
                  "shufps", "unpcklps", "unpckhps",
                  "addps", "subps", "mulps", "divps",
@@ -1398,10 +1401,21 @@ class Lifter:
         if nops < 1:
             return [f"/* {m}: no operands */"]
 
-        # SSE register names (xmm0-xmm7) are used as float locals
+        def _is_xmm(op):
+            return op.type == "reg" and op.reg and op.reg.startswith("xmm")
+
+        def _is_mmx(op):
+            return (op.type == "reg" and op.reg and op.reg.startswith("mm")
+                    and not op.reg.startswith("xmm"))
+
+        # ── Scalar (lane 0) access ──
+        # movss/addss/... genuinely operate on one 32-bit value, so they read
+        # and write lane 0 explicitly rather than the whole register.
         def _sse_read(op):
-            if op.type == "reg":
-                return op.reg  # xmm0, xmm1, etc.
+            if _is_xmm(op):
+                return f"{op.reg}.f[0]"
+            elif op.type == "reg":
+                return op.reg
             elif op.type == "mem":
                 if op.mem_size == 8:
                     return f"MEMD({_fmt_mem(op)})"
@@ -1411,7 +1425,9 @@ class Lifter:
             return f"/* sse_read? */"
 
         def _sse_write(op, val):
-            if op.type == "reg":
+            if _is_xmm(op):
+                return f"{op.reg}.f[0] = {val};"
+            elif op.type == "reg":
                 return f"{op.reg} = {val};"
             elif op.type == "mem":
                 if op.mem_size == 8:
@@ -1419,20 +1435,101 @@ class Lifter:
                 return f"MEMF({_fmt_mem(op)}) = {val};"
             return f"/* sse_write? */;"
 
+        # ── Packed (128-bit) access ──
+        # A whole-register read yields a RecompXmm value; a whole-register
+        # write is a statement. Memory goes through the guest translation.
+        def _packed_read(op):
+            if _is_xmm(op):
+                return op.reg
+            if op.type == "mem":
+                return f"XMM_MEM({_fmt_mem(op)})"
+            return None
+
+        def _packed_write(op, val):
+            if _is_xmm(op):
+                return f"{op.reg} = {val};"
+            if op.type == "mem":
+                return f"XMM_STORE({_fmt_mem(op)}, {val});"
+            return None
+
+        def _packed_binary(helper):
+            """dst = helper(dst, src) for a two-operand packed op."""
+            if nops < 2:
+                return None
+            a = _packed_read(ops[0])
+            b = _packed_read(ops[1])
+            if a is None or b is None:
+                return None
+            written = _packed_write(ops[0], f"{helper}({a}, {b})")
+            if written is None:
+                return None
+            return [written + f" /* {m} */"]
+
         # ── Moves ──
-        if m in ("movss", "movsd", "movaps", "movups", "movlps", "movhps"):
+        # movaps/movups move all 16 bytes. Treating them like movss was the
+        # defect that left every packed value 4 bytes wide.
+        if m in ("movaps", "movups", "movapd", "movupd"):
             if nops >= 2:
+                src = _packed_read(ops[1])
+                if src is not None:
+                    written = _packed_write(ops[0], src)
+                    if written is not None:
+                        return [written + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+
+        # movlps/movhps transfer 8 bytes into or out of one half.
+        if m in ("movlps", "movhps"):
+            half = "LOW" if m == "movlps" else "HIGH"
+            if nops >= 2:
+                if _is_xmm(ops[0]) and ops[1].type == "mem":
+                    return [f"XMM_LOAD_{half}({ops[0].reg}, "
+                            f"{_fmt_mem(ops[1])}); /* {m} */"]
+                if ops[0].type == "mem" and _is_xmm(ops[1]):
+                    return [f"XMM_STORE_{half}({_fmt_mem(ops[0])}, "
+                            f"{ops[1].reg}); /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+
+        if m in ("movlhps", "movhlps"):
+            helper = ("XMM_MOVE_LOW_TO_HIGH" if m == "movlhps"
+                      else "XMM_MOVE_HIGH_TO_LOW")
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
+
+        # movss/movsd are scalar. Loading from memory zeroes the upper lanes;
+        # a register-to-register move leaves them untouched.
+        if m in ("movss", "movsd"):
+            if nops >= 2:
+                scalar = ("XMM_SCALAR" if m == "movss"
+                          else "XMM_SCALAR_DOUBLE")
+                if _is_xmm(ops[0]) and ops[1].type == "mem":
+                    return [f"{ops[0].reg} = "
+                            f"{scalar}({_sse_read(ops[1])}); /* {m} */"]
                 src = _sse_read(ops[1])
                 return [_sse_write(ops[0], src) + f" /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
+        # movd moves 32 bits without converting. Into an XMM register it also
+        # zeroes the upper lanes. The generated code redefines memcpy as a
+        # guest-to-guest copy, so the bits are moved through the union instead
+        # of taking the address of a host local.
         if m == "movd":
             if nops >= 2:
-                src = _fmt_operand_read(ops[1]) if ops[1].type != "reg" or not ops[1].reg.startswith("xmm") else _sse_read(ops[1])
-                if ops[0].type == "reg" and ops[0].reg.startswith("xmm"):
-                    return [f"memcpy(&{ops[0].reg}, &{src}, 4); /* movd to xmm */"]
-                else:
-                    return [f"{_fmt_operand_write(ops[0], src)} /* movd */"]
+                if _is_xmm(ops[0]):
+                    if _is_xmm(ops[1]):
+                        src = f"{ops[1].reg}.u[0]"
+                    elif _is_mmx(ops[1]):
+                        src = f"(uint32_t){ops[1].reg}"
+                    else:
+                        src = _fmt_operand_read(ops[1])
+                    return [f"{ops[0].reg} = XMM_SCALAR_BITS({src});"
+                            " /* movd to xmm */"]
+                if _is_xmm(ops[1]):
+                    return [f"{_fmt_operand_write(ops[0], ops[1].reg + '.u[0]')}"
+                            " /* movd */"]
+                src = _fmt_operand_read(ops[1])
+                return [f"{_fmt_operand_write(ops[0], src)} /* movd */"]
             return [f"/* movd {insn.op_str} */"]
 
         # ── Arithmetic ──
@@ -1461,11 +1558,15 @@ class Lifter:
                 return [_sse_write(ops[0], f"({a} > {b} ? {a} : {b})") + f" /* {m} */"]
 
         # ── Packed arithmetic ──
+        # These used to emit a bare comment, so a matrix concatenation built
+        # from shufps + mulps + addps executed as nothing at all.
         if m in ("addps", "subps", "mulps", "divps"):
-            if nops >= 2:
-                c_op = {"addps": "+", "subps": "-", "mulps": "*", "divps": "/"}[m]
-                d, s = _sse_read(ops[0]), _sse_read(ops[1])
-                return [f"/* {m}: {d} {c_op}= {s} (packed 4xfloat) */"]
+            helper = {"addps": "XMM_ADD", "subps": "XMM_SUB",
+                      "mulps": "XMM_MUL", "divps": "XMM_DIV"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Conversions ──
         if m == "cvtsi2ss":
@@ -1495,19 +1596,31 @@ class Lifter:
                 return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} - sets EFLAGS */"]
 
         # ── Bitwise ──
+        # Done on the integer lanes: these carry sign-mask and select idioms
+        # (fabs, negate, blend) that are meaningless as float arithmetic.
         if m in ("xorps", "xorpd"):
-            if nops >= 2 and ops[0].type == "reg" and ops[1].type == "reg" and ops[0].reg == ops[1].reg:
-                return [_sse_write(ops[0], "0.0f") + f" /* {m} self = zero */"]
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} */"]
-        if m in ("andps", "orps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} */"]
+            if (nops >= 2 and _is_xmm(ops[0]) and _is_xmm(ops[1])
+                    and ops[0].reg == ops[1].reg):
+                return [f"{ops[0].reg} = XMM_ZERO(); /* {m} self = zero */"]
+            lifted = _packed_binary("XMM_XOR")
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
+        if m in ("andps", "orps", "andnps"):
+            helper = {"andps": "XMM_AND", "orps": "XMM_OR",
+                      "andnps": "XMM_ANDN"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Packed min/max ──
         if m in ("minps", "maxps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} (packed 4xfloat) */"]
+            helper = "XMM_MIN" if m == "minps" else "XMM_MAX"
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Reciprocal / rsqrt ──
         if m == "rsqrtss":
@@ -1541,13 +1654,22 @@ class Lifter:
 
         # ── Packed comparison ──
         if m in ("cmpneqps", "cmpeqps", "cmpltps", "cmpleps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} (packed compare) */"]
+            helper = {"cmpeqps": "XMM_CMP_EQ", "cmpltps": "XMM_CMP_LT",
+                      "cmpleps": "XMM_CMP_LE", "cmpneqps": "XMM_CMP_NEQ"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Move mask ──
+        # This feeds branches, so a hardcoded 0 silently picked one side.
         if m == "movmskps":
             if nops >= 2:
-                return [_fmt_operand_write(ops[0], f"0 /* movmskps {_sse_read(ops[1])} */")]
+                src = _packed_read(ops[1])
+                if src is not None:
+                    return [_fmt_operand_write(ops[0], f"XMM_MOVEMASK({src})")
+                            + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── MMX / integer SIMD ──
         if m in ("pand", "pandn", "por", "pxor", "pcmpgtd"):
@@ -1555,7 +1677,24 @@ class Lifter:
                 return [f"/* {m} {insn.op_str} (MMX/SIMD integer) */"]
 
         # ── Shuffle/unpack ──
-        if m in ("shufps", "unpcklps", "unpckhps"):
+        # shufps is the broadcast in every matrix concatenation.
+        if m == "shufps":
+            if nops >= 3 and ops[2].type == "imm":
+                a = _packed_read(ops[0])
+                b = _packed_read(ops[1])
+                if a is not None and b is not None:
+                    written = _packed_write(
+                        ops[0],
+                        f"XMM_SHUFFLE({a}, {b}, {_fmt_imm(ops[2].imm)})")
+                    if written is not None:
+                        return [written + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+        if m in ("unpcklps", "unpckhps"):
+            helper = ("XMM_UNPACK_LOW" if m == "unpcklps"
+                      else "XMM_UNPACK_HIGH")
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
             return [f"/* {m} {insn.op_str} */"]
 
         return [f"/* SSE: {m} {insn.op_str} */"]
@@ -1638,12 +1777,91 @@ class Lifter:
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdiv */"]
         if m == "fdivp":
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdivp */"]
+        # Reverse forms compute source-minus-destination, not the other way
+        # round. There was no case for them, so they fell through to the
+        # bare-comment catch-all below and executed as nothing: fdivr against
+        # the constant 1.0 is the reciprocal inside the vector-normalize
+        # helper, so dropping it turned "v / len" into "v * len".
+        if m == "fsubr":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() = {source} - fp_top();"
+                            f" /* fsubr {insn.op_str} */"]
+            return [f"fp_st1() = fp_top() - fp_st1(); fp_pop(); /* fsubr */"]
+        if m == "fsubrp":
+            return [f"fp_st1() = fp_top() - fp_st1(); fp_pop(); /* fsubrp */"]
+        if m == "fdivr":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() = {source} / fp_top();"
+                            f" /* fdivr {insn.op_str} */"]
+            return [f"fp_st1() = fp_top() / fp_st1(); fp_pop(); /* fdivr */"]
+        if m == "fdivrp":
+            return [f"fp_st1() = fp_top() / fp_st1(); fp_pop(); /* fdivrp */"]
+        # Integer-memory arithmetic: the operand is a signed integer in
+        # memory, converted to double before the operation.
+        if m in ("fiadd", "fisub", "fisubr", "fimul", "fidiv", "fidivr"):
+            if ops and ops[0].type == "mem":
+                smem = _smem_accessor(ops[0].mem_size)
+                source = f"(double){smem}({_fmt_mem(ops[0])})"
+                op_text = {
+                    "fiadd": f"fp_top() += {source};",
+                    "fisub": f"fp_top() -= {source};",
+                    "fisubr": f"fp_top() = {source} - fp_top();",
+                    "fimul": f"fp_top() *= {source};",
+                    "fidiv": f"fp_top() /= {source};",
+                    "fidivr": f"fp_top() = {source} / fp_top();",
+                }[m]
+                return [op_text + f" /* {m} {insn.op_str} */"]
+            return [f"/* {m} {insn.op_str} - no memory operand */"]
         if m == "fchs":
             return [f"fp_top() = -fp_top(); /* fchs */"]
         if m == "fabs":
             return [f"fp_top() = fabs(fp_top()); /* fabs */"]
         if m == "fsqrt":
             return [f"fp_top() = sqrt(fp_top()); /* fsqrt */"]
+        # Transcendentals. fpatan is the core of the atan2 helper the
+        # view-matrix path calls; dropping it left an unbalanced stack value.
+        if m == "fpatan":
+            return [f"fp_st1() = atan2(fp_st1(), fp_top()); fp_pop();"
+                    f" /* fpatan */"]
+        if m == "fsin":
+            return [f"fp_top() = sin(fp_top()); /* fsin */"]
+        if m == "fcos":
+            return [f"fp_top() = cos(fp_top()); /* fcos */"]
+        if m == "fsincos":
+            return [f"{{ double _s = sin(fp_top()); "
+                    f"fp_top() = cos(fp_top()); fp_push(_s); }} /* fsincos */"]
+        if m == "fptan":
+            return [f"fp_top() = tan(fp_top()); fp_push(1.0); /* fptan */"]
+        if m == "f2xm1":
+            return [f"fp_top() = pow(2.0, fp_top()) - 1.0; /* f2xm1 */"]
+        if m == "fyl2x":
+            return [f"fp_st1() = fp_st1() * log2(fp_top()); fp_pop();"
+                    f" /* fyl2x */"]
+        if m == "fyl2xp1":
+            return [f"fp_st1() = fp_st1() * log2(fp_top() + 1.0); fp_pop();"
+                    f" /* fyl2xp1 */"]
+        if m == "fscale":
+            return [f"fp_top() = fp_top() * pow(2.0, trunc(fp_st1()));"
+                    f" /* fscale */"]
+        if m == "frndint":
+            return [f"fp_top() = rint(fp_top()); /* frndint */"]
+        if m == "fldpi":
+            return [f"fp_push(3.14159265358979323846); /* fldpi */"]
+        if m == "fldl2e":
+            return [f"fp_push(1.44269504088896340736); /* fldl2e */"]
+        if m == "fldl2t":
+            return [f"fp_push(3.32192809488736234787); /* fldl2t */"]
+        if m == "fldlg2":
+            return [f"fp_push(0.30102999566398119521); /* fldlg2 */"]
+        if m == "fldln2":
+            return [f"fp_push(0.69314718055994530942); /* fldln2 */"]
+        if m == "ftst":
+            return [f"g_fp_cmp = (fp_top() < 0.0) ? -1 : "
+                    f"(fp_top() > 0.0) ? 1 : 0; /* ftst */"]
         if m == "fxch":
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -322,7 +322,7 @@ def _make_condition(jcc, flag_setter, flag_ops):
         }
         op = fpu_cmp_map.get(jcc)
         if op:
-            return f"(_fpu_cmp {op} 0) /* {flag_setter} */", desc
+            return f"(g_fp_cmp {op} 0) /* {flag_setter} */", desc
         if jcc == "jp":
             return "0 /* fpu: unordered/NaN */", desc
         if jcc == "jnp":
@@ -373,7 +373,8 @@ def _make_condition(jcc, flag_setter, flag_ops):
         if jcc == "jns":
             return f"((int32_t)({lhs} - {rhs}) >= 0)", desc
         if jcc in ("jp", "jnp"):
-            return f"1 /* {jcc} after cmp - parity */", desc
+            sense = "" if jcc == "jp" else "!"
+            return f"{sense}PARITY8({lhs} - {rhs})", desc
         return None
 
     # ── test: flags from (a & b), operands unchanged ──
@@ -391,7 +392,10 @@ def _make_condition(jcc, flag_setter, flag_ops):
         if jcc == "jno":
             return "1", desc
         if jcc in ("jp", "jnp"):
-            return f"1 /* {jcc} after test - parity */", desc
+            # PF is the even-parity of the low byte of the result. The CRT
+            # branches on it after FNSTSW/TEST AH, so compute it.
+            sense = "" if jcc == "jp" else "!"
+            return f"{sense}PARITY8({lhs} & {rhs})", desc
         return None
 
     # ── sub: a = a - b, flags from (a_orig - b) ──
@@ -1643,11 +1647,11 @@ class Lifter:
         if m == "fxch":
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):
-            # Set _fpu_cmp for the fcomp/fnstsw/sahf pattern
+            # Set g_fp_cmp for the fcomp/fnstsw/sahf pattern
             source = _fmt_fpu_operand(ops[-1]) if ops else "fp_st1()"
             pops = 2 if m.endswith("pp") else 1 if m.endswith("p") else 0
             pop_code = " fp_pop();" * pops
-            return [f"_fpu_cmp = (fp_top() < {source}) ? -1 : "
+            return [f"g_fp_cmp = (fp_top() < {source}) ? -1 : "
                     f"(fp_top() > {source}) ? 1 : 0;{pop_code}"
                     f" /* {m} {insn.op_str} */"]
         if m in ("fcompi", "fcomip", "fucomi", "fucompi", "fucomip", "fcomi"):
@@ -1655,14 +1659,40 @@ class Lifter:
             # fcompi/fucompi pop st(0) after comparing; fcomi/fucomi do not
             pops = m.endswith("pi") or m.endswith("ip")
             pop_code = " fp_pop();" if pops else ""
-            return [f"_fpu_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
+            return [f"g_fp_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
                     f"{pop_code} /* {m} */"]
         if m == "fnstsw":
-            return [f"/* fnstsw {insn.op_str} - store FPU status word */"]
+            # C3/C2/C0 occupy bits 14/10/8, which land in AH as 0x40/0x04/
+            # 0x01. The CRT tests AH to classify the preceding compare, so
+            # rebuild them from g_fp_cmp instead of dropping the store.
+            status = ("(uint16_t)(g_fp_cmp < 0 ? 0x0100u :"
+                      " g_fp_cmp > 0 ? 0x0000u : 0x4000u)")
+            if ops and ops[0].type == "mem":
+                return [f"MEM16({_fmt_mem(ops[0])}) = {status};"
+                        f" /* fnstsw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [_fmt_set_reg(ops[0].reg, status)
+                        + f" /* fnstsw {insn.op_str} */"]
+            return [f"/* fnstsw {insn.op_str} - no destination operand */"]
         if m == "fnstcw":
-            return [f"/* fnstcw {insn.op_str} - store FPU control word */"]
+            # The CRT reads the control word back to decide whether an
+            # exception is masked, so it must be stored, not dropped.
+            if ops and ops[0].type == "mem":
+                return [f"MEM16({_fmt_mem(ops[0])}) = g_fp_control_word;"
+                        f" /* fnstcw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [_fmt_set_reg(ops[0].reg, "g_fp_control_word")
+                        + f" /* fnstcw {insn.op_str} */"]
+            return [f"/* fnstcw {insn.op_str} - no destination operand */"]
         if m == "fldcw":
-            return [f"/* fldcw {insn.op_str} - load FPU control word */"]
+            if ops and ops[0].type == "mem":
+                return [f"g_fp_control_word = MEM16({_fmt_mem(ops[0])});"
+                        f" /* fldcw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [f"g_fp_control_word = (uint16_t)"
+                        f"{_fmt_operand_read(ops[0])};"
+                        f" /* fldcw {insn.op_str} */"]
+            return [f"/* fldcw {insn.op_str} - no source operand */"]
         if m == "fldz":
             return [f"fp_push(0.0); /* fldz */"]
         if m == "fld1":

--- a/tools/recomp/test_lifter_fpu.py
+++ b/tools/recomp/test_lifter_fpu.py
@@ -113,6 +113,54 @@ class FpuLifterTest(unittest.TestCase):
         self.assertIn("#define SMEM64(addr)", runtime_types)
         self.assertIn("double g_fp_stack[8];", main)
         self.assertIn("uint32_t g_fp_top;", main)
+        self.assertIn("extern uint16_t g_fp_control_word;", runtime_types)
+        self.assertIn("#define PARITY8(value)", runtime_types)
+        self.assertIn("uint16_t g_fp_control_word", main)
+
+    def test_control_word_store_and_load_use_shared_state(self):
+        operand = Operand(type="mem", mem_base="ebp", mem_disp=0xFFFFFFFC,
+                          mem_size=2)
+        store = Instruction(0, 3, "fnstcw", "word ptr [ebp - 4]", "")
+        store.operands = [operand]
+        load = Instruction(0, 3, "fldcw", "word ptr [ebp - 4]", "")
+        load.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["MEM16(ebp + 0xFFFFFFFCu) = g_fp_control_word;"
+             " /* fnstcw word ptr [ebp - 4] */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(load),
+            ["g_fp_control_word = MEM16(ebp + 0xFFFFFFFCu);"
+             " /* fldcw word ptr [ebp - 4] */"],
+        )
+
+    def test_status_word_store_reports_the_compare_result(self):
+        instruction = Instruction(0, 2, "fnstsw", "ax", "dfe0")
+        instruction.operands = [Operand(type="reg", reg="ax")]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        # The compare can live in a different lifted body than the FNSTSW that
+        # reads it, so the result has to be shared state, not a function local.
+        self.assertIn("g_fp_cmp", lifted[0])
+        self.assertNotIn("_fpu_cmp", lifted[0])
+        self.assertIn("0x4000u", lifted[0])
+        self.assertNotIn("/* fnstsw ax - store FPU status word */", lifted[0])
+
+    def test_compare_writes_the_shared_result(self):
+        instruction = Instruction(0, 4, "fcomp", "qword ptr [ebp + 8]", "dc5d08")
+        instruction.operands = [
+            Operand(type="mem", mem_base="ebp", mem_disp=8, mem_size=8)
+        ]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertTrue(lifted[0].startswith("g_fp_cmp ="))
+        self.assertNotIn("_fpu_cmp", lifted[0])
 
 
 if __name__ == "__main__":

--- a/tools/recomp/test_lifter_fpu.py
+++ b/tools/recomp/test_lifter_fpu.py
@@ -1,0 +1,119 @@
+import unittest
+from pathlib import Path
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter
+from .translator import FunctionTranslator
+
+
+class FpuLifterTest(unittest.TestCase):
+    def test_stack_register_load_duplicates_the_old_top(self):
+        instruction = Instruction(0, 2, "fld", "st(0)", "d9c0")
+        instruction.operands = [Operand(type="reg", reg="st(0)")]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_push(fp_st(0)); /* fld st(0) */"],
+        )
+
+    def test_fst_does_not_pop_and_fstp_does(self):
+        operand = Operand(type="mem", mem_base="esp", mem_disp=0x18,
+                          mem_size=4)
+        store = Instruction(0, 4, "fst", "dword ptr [esp + 0x18]", "")
+        store.operands = [operand]
+        store_pop = Instruction(
+            0, 4, "fstp", "dword ptr [esp + 0x18]", "")
+        store_pop.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["MEMF(esp + 0x18) = (float)fp_top(); /* fst */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(store_pop),
+            ["MEMF(esp + 0x18) = (float)fp_top(); fp_pop(); /* fstp */"],
+        )
+
+    def test_qword_integer_conversion_uses_signed_64_bit_storage(self):
+        operand = Operand(type="mem", mem_base="esp", mem_disp=0x10,
+                          mem_size=8)
+        store = Instruction(
+            0, 4, "fistp", "qword ptr [esp + 0x10]", "")
+        store.operands = [operand]
+        load = Instruction(0, 4, "fild", "qword ptr [esp + 0x10]", "")
+        load.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["SMEM64(esp + 0x10) = (int64_t)llrint(fp_top()); "
+             "fp_pop(); /* fistp */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(load),
+            ["fp_push((double)SMEM64(esp + 0x10)); /* fild */"],
+        )
+
+    def test_memory_arithmetic_updates_st0_without_popping(self):
+        instruction = Instruction(
+            0, 6, "fdiv", "dword ptr [0x00123456]", "")
+        instruction.operands = [
+            Operand(type="mem", mem_disp=0x00123456, mem_size=4),
+        ]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_top() /= MEMF(0x123456); "
+             "/* fdiv dword ptr [0x00123456] */"],
+        )
+
+    def test_register_arithmetic_updates_st0_without_popping(self):
+        instruction = Instruction(0, 2, "fmul", "st(1)", "d8c9")
+        instruction.operands = [Operand(type="reg", reg="st(1)")]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_top() *= fp_st(1); /* fmul st(1) */"],
+        )
+
+    def test_translated_functions_share_runtime_fpu_state(self):
+        start = 0x00010000
+        instructions = [
+            Instruction(start, 2, "fld", "st(0)", "d9c0"),
+            Instruction(start + 2, 1, "ret", "", "c3"),
+        ]
+        instructions[0].operands = [Operand(type="reg", reg="st(0)")]
+        block = BasicBlock(start=start, instructions=instructions)
+        translator = FunctionTranslator(
+            b"\0", {start: {"_addr": start, "end": start + 3}})
+        translator._read_func_bytes = lambda _start, _end: b"\xd9\xc0\xc3"
+        translator.disasm.disassemble_function = (
+            lambda _raw, _start, _end: instructions)
+        translator.disasm.build_basic_blocks = (
+            lambda _instructions, _start, _end, extra_leaders=None: [block])
+
+        generated = translator.translate_function(
+            start, {"_addr": start, "end": start + 3})
+
+        self.assertIn("g_fp_stack", generated)
+        self.assertIn("g_fp_top", generated)
+        self.assertNotIn("double _fp_stack[8]", generated)
+        self.assertNotIn("int _fp_top = 0", generated)
+
+    def test_runtime_template_exports_shared_fpu_state(self):
+        root = Path(__file__).resolve().parents[2]
+        runtime_types = (
+            root / "templates" / "runtime" / "recomp_types.h"
+        ).read_text()
+        main = (
+            root / "templates" / "new-game" / "src" / "main.c"
+        ).read_text()
+
+        self.assertIn("extern double g_fp_stack[8];", runtime_types)
+        self.assertIn("extern uint32_t g_fp_top;", runtime_types)
+        self.assertIn("#define SMEM64(addr)", runtime_types)
+        self.assertIn("double g_fp_stack[8];", main)
+        self.assertIn("uint32_t g_fp_top;", main)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_fpu_reverse.py
+++ b/tools/recomp/test_lifter_fpu_reverse.py
@@ -1,0 +1,84 @@
+"""The x87 reverse-operand, integer-memory and transcendental forms.
+
+None of these had a case in _lift_fpu, so every one of them fell through to
+the bare-comment catch-all and executed as nothing at all. The stack depth
+stayed balanced while the value did not, so the wrong number flowed forward
+silently. fdivr against the constant 1.0 is the reciprocal inside the
+vector-normalize helper, which is why the view matrix read back scaled by
+the square of its own length instead of unit-length.
+"""
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+def _mem(base=None, disp=0, size=4):
+    return Operand(type="mem", mem_base=base, mem_disp=disp, mem_size=size)
+
+
+def _lift(mnemonic, op_str, operands):
+    instruction = Instruction(0, 4, mnemonic, op_str, "")
+    instruction.operands = operands
+    return Lifter().lift_instruction(instruction)
+
+
+class FpuReverseFormTest(unittest.TestCase):
+    def test_fdivr_divides_the_operand_by_the_stack_top(self):
+        """1.0 fdivr len is the reciprocal, not len / 1.0."""
+        lifted = _lift("fdivr", "dword ptr [0x281250]", [_mem(disp=0x281250)])
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("fp_top() = MEMF(0x281250) / fp_top();", lifted[0])
+        self.assertNotIn("/* FPU:", lifted[0])
+
+    def test_fsubr_subtracts_the_stack_top_from_the_operand(self):
+        lifted = _lift("fsubr", "dword ptr [eax + 0x10]",
+                       [_mem(base="eax", disp=0x10)])
+
+        self.assertIn("fp_top() = MEMF(eax + 0x10) - fp_top();", lifted[0])
+
+    def test_reverse_pop_forms_use_the_reversed_operand_order(self):
+        self.assertIn("fp_st1() = fp_top() / fp_st1(); fp_pop();",
+                      _lift("fdivrp", "st(1)", [])[0])
+        self.assertIn("fp_st1() = fp_top() - fp_st1(); fp_pop();",
+                      _lift("fsubrp", "st(1)", [])[0])
+
+    def test_forward_forms_keep_their_original_operand_order(self):
+        """The reverse cases must not disturb the plain ones."""
+        self.assertIn("fp_top() /= MEMF(eax);",
+                      _lift("fdiv", "dword ptr [eax]", [_mem(base="eax")])[0])
+        self.assertIn("fp_top() -= MEMF(eax);",
+                      _lift("fsub", "dword ptr [eax]", [_mem(base="eax")])[0])
+
+    def test_integer_memory_operands_are_read_as_signed_integers(self):
+        lifted = _lift("fidiv", "dword ptr [esp + 8]",
+                       [_mem(base="esp", disp=8)])
+
+        self.assertIn("fp_top() /= (double)SMEM32(esp + 8);", lifted[0])
+
+        word = _lift("fisubr", "word ptr [ebx + 0xbc]",
+                     [_mem(base="ebx", disp=0xBC, size=2)])
+        self.assertIn("fp_top() = (double)SMEM16(ebx + 0xBC) - fp_top();",
+                      word[0])
+
+    def test_transcendentals_emit_statements_rather_than_comments(self):
+        for mnemonic, expected in (
+            ("fpatan", "atan2(fp_st1(), fp_top())"),
+            ("fsin", "sin(fp_top())"),
+            ("fcos", "cos(fp_top())"),
+            ("frndint", "rint(fp_top())"),
+            ("fyl2x", "log2(fp_top())"),
+        ):
+            with self.subTest(mnemonic=mnemonic):
+                lifted = _lift(mnemonic, "", [])
+                self.assertIn(expected, lifted[0])
+                self.assertNotIn("/* FPU:", lifted[0])
+
+    def test_fptan_pushes_the_implicit_one(self):
+        """FPTAN leaves tan(x) and then 1.0 on the stack."""
+        self.assertIn("fp_push(1.0);", _lift("fptan", "", [])[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_sse.py
+++ b/tools/recomp/test_lifter_sse.py
@@ -1,0 +1,175 @@
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+def _insn(mnemonic, op_str, operands):
+    instruction = Instruction(0, 4, mnemonic, op_str, "")
+    instruction.operands = operands
+    return instruction
+
+
+def _xmm(name):
+    return Operand(type="reg", reg=name)
+
+
+def _mem(base=None, disp=0, size=16):
+    return Operand(type="mem", mem_base=base, mem_disp=disp, mem_size=size)
+
+
+class SsePackedLifterTest(unittest.TestCase):
+    """An XMM register is 128 bits wide. Lifting packed moves as scalar
+    floats transferred 4 of every 16 bytes, which left every matrix built by
+    packed SSE sparse, and dropped packed arithmetic to a bare comment."""
+
+    def test_aligned_packed_load_transfers_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movaps", "xmm0, xmmword ptr [eax]",
+                      [_xmm("xmm0"), _mem("eax")])),
+            ["xmm0 = XMM_MEM(eax); /* movaps */"],
+        )
+
+    def test_aligned_packed_store_transfers_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movaps", "xmmword ptr [ecx], xmm0",
+                      [_mem("ecx"), _xmm("xmm0")])),
+            ["XMM_STORE(ecx, xmm0); /* movaps */"],
+        )
+
+    def test_unaligned_packed_move_is_also_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movups", "xmmword ptr [ecx + 0x10], xmm1",
+                      [_mem("ecx", 0x10), _xmm("xmm1")])),
+            ["XMM_STORE(ecx + 0x10, xmm1); /* movups */"],
+        )
+
+    def test_scalar_move_stays_on_lane_zero(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movss", "xmm0, dword ptr [eax + 4]",
+                      [_xmm("xmm0"), _mem("eax", 4, size=4)])),
+            ["xmm0 = XMM_SCALAR(MEMF(eax + 4)); /* movss */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movss", "dword ptr [ecx], xmm2",
+                      [_mem("ecx", 0, size=4), _xmm("xmm2")])),
+            ["MEMF(ecx) = xmm2.f[0]; /* movss */"],
+        )
+
+    def test_packed_arithmetic_emits_a_statement(self):
+        for mnemonic, helper in (("mulps", "XMM_MUL"), ("addps", "XMM_ADD"),
+                                 ("subps", "XMM_SUB"), ("divps", "XMM_DIV")):
+            self.assertEqual(
+                Lifter().lift_instruction(
+                    _insn(mnemonic, "xmm0, xmm1",
+                          [_xmm("xmm0"), _xmm("xmm1")])),
+                ["xmm0 = %s(xmm0, xmm1); /* %s */" % (helper, mnemonic)],
+            )
+
+    def test_packed_arithmetic_against_memory(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("mulps", "xmm0, xmmword ptr [0xa24190]",
+                      [_xmm("xmm0"), _mem(disp=0xA24190)])),
+            ["xmm0 = XMM_MUL(xmm0, XMM_MEM(0xA24190)); /* mulps */"],
+        )
+
+    def test_shuffle_uses_the_immediate(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("shufps", "xmm7, xmm7, 0",
+                      [_xmm("xmm7"), _xmm("xmm7"),
+                       Operand(type="imm", imm=0)])),
+            ["xmm7 = XMM_SHUFFLE(xmm7, xmm7, 0); /* shufps */"],
+        )
+
+    def test_bitwise_ops_use_the_integer_lanes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("andps", "xmm4, xmmword ptr [0x240430]",
+                      [_xmm("xmm4"), _mem(disp=0x240430)])),
+            ["xmm4 = XMM_AND(xmm4, XMM_MEM(0x240430)); /* andps */"],
+        )
+
+    def test_self_xor_zeroes_the_whole_register(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("xorps", "xmm0, xmm0",
+                      [_xmm("xmm0"), _xmm("xmm0")])),
+            ["xmm0 = XMM_ZERO(); /* xorps self = zero */"],
+        )
+
+    def test_move_mask_gathers_real_sign_bits(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movmskps", "eax, xmm3",
+                      [Operand(type="reg", reg="eax"), _xmm("xmm3")])),
+            ["eax = XMM_MOVEMASK(xmm3); /* movmskps */"],
+        )
+
+    def test_half_width_moves_target_one_half(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movlps", "xmm0, qword ptr [ecx]",
+                      [_xmm("xmm0"), _mem("ecx", 0, size=8)])),
+            ["XMM_LOAD_LOW(xmm0, ecx); /* movlps */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movhps", "qword ptr [eax + 8], xmm1",
+                      [_mem("eax", 8, size=8), _xmm("xmm1")])),
+            ["XMM_STORE_HIGH(eax + 8, xmm1); /* movhps */"],
+        )
+
+    def test_scalar_arithmetic_reads_and_writes_lane_zero(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("mulss", "xmm0, xmm1",
+                      [_xmm("xmm0"), _xmm("xmm1")])),
+            ["xmm0.f[0] = xmm0.f[0] * xmm1.f[0]; /* mulss */"],
+        )
+
+    def test_no_packed_mnemonic_falls_through_to_a_bare_comment(self):
+        packed = [
+            ("movaps", [_xmm("xmm0"), _mem("eax")]),
+            ("movups", [_xmm("xmm0"), _mem("eax")]),
+            ("movlps", [_xmm("xmm0"), _mem("eax", 0, size=8)]),
+            ("movhps", [_xmm("xmm0"), _mem("eax", 0, size=8)]),
+            ("movlhps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("movhlps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("addps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("subps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("mulps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("divps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("minps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("maxps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("andps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("andnps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("orps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("xorps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("unpcklps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("unpckhps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpeqps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpneqps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpltps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpleps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("shufps", [_xmm("xmm0"), _xmm("xmm1"),
+                        Operand(type="imm", imm=0x55)]),
+            ("movmskps", [Operand(type="reg", reg="eax"), _xmm("xmm0")]),
+        ]
+        for mnemonic, operands in packed:
+            lifted = Lifter().lift_instruction(_insn(mnemonic, "", operands))
+            self.assertEqual(len(lifted), 1, mnemonic)
+            statement = lifted[0]
+            self.assertIn(";", statement, (mnemonic, statement))
+            self.assertFalse(
+                statement.lstrip().startswith("/*"), (mnemonic, statement))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -312,15 +312,17 @@ class FunctionTranslator:
             if mmx_regs:
                 lines.append(f"    uint64_t {', '.join(mmx_regs)};")
 
-        # FPU stack (simplified)
+        # The x87 stack is architectural state and survives guest calls. Some
+        # detector boundaries also split one original CRT helper into several
+        # generated C functions, so function-local storage loses live ST values.
         if has_fpu:
-            lines.append(f"    double _fp_stack[8];")
-            lines.append(f"    int _fp_top = 0;")
-            lines.append(f"    #define fp_push(v) (_fp_stack[--_fp_top & 7] = (v))")
-            lines.append(f"    #define fp_pop() (_fp_top++)")
-            lines.append(f"    #define fp_popp() (fp_pop())")
-            lines.append(f"    #define fp_top() _fp_stack[_fp_top & 7]")
-            lines.append(f"    #define fp_st1() _fp_stack[(_fp_top + 1) & 7]")
+            lines.append(f"    #define fp_push(v) do {{ double _fp_value = (v); \\")
+            lines.append(f"        g_fp_top = (g_fp_top + 7u) & 7u; \\")
+            lines.append(f"        g_fp_stack[g_fp_top] = _fp_value; }} while (0)")
+            lines.append(f"    #define fp_pop() (g_fp_top = (g_fp_top + 1u) & 7u)")
+            lines.append(f"    #define fp_top() g_fp_stack[g_fp_top]")
+            lines.append(f"    #define fp_st(i) g_fp_stack[(g_fp_top + (i)) & 7u]")
+            lines.append(f"    #define fp_st1() fp_st(1)")
 
         # For fpo_leaf functions that use ebp: initialize from g_seh_ebp.
         # In x86, these functions inherit EBP from their caller (typically
@@ -418,8 +420,8 @@ class FunctionTranslator:
         if has_fpu:
             lines.append(f"    #undef fp_push")
             lines.append(f"    #undef fp_pop")
-            lines.append(f"    #undef fp_popp")
             lines.append(f"    #undef fp_top")
+            lines.append(f"    #undef fp_st")
             lines.append(f"    #undef fp_st1")
 
         lines.append(f"}}")

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -293,15 +293,6 @@ class FunctionTranslator:
         if has_carry:
             lines.append(f"    int _cf = 0; /* carry flag */")
 
-        # Add _fpu_cmp for FPU compare instructions (both old and new style)
-        has_fpu_cmp = any(insn.mnemonic in ("fcompi", "fcomip", "fucomi",
-                                             "fucompi", "fucomip", "fcomi",
-                                             "fcom", "fcomp", "fcompp",
-                                             "fucom", "fucomp", "fucompp")
-                          for insn in instructions)
-        if has_fpu_cmp:
-            lines.append(f"    int _fpu_cmp = 0; /* FPU compare result: -1/0/1 */")
-
         # SSE/MMX register declarations
         if used_xmm:
             xmm_regs = sorted([r for r in used_xmm if r.startswith("xmm")])


### PR DESCRIPTION
## What this fixes

The two biggest silent-data-loss classes I found: packed SSE treated as scalar,
and most of x87 dropped to comments.

### 1. Packed SSE was lifted as scalar `float`

XMM registers were modeled as a single `float`, so `movaps`/`movups` **transferred
4 of 16 bytes** — the upper three lanes were silently discarded. **18,439 moves**
on the title I tested. Packed arithmetic (`addps`, `mulps`, `shufps`, and friends)
had no pattern at all and **561 operations were dropped outright**.

XMM is now a 16-byte union with per-lane access, and the packed forms lift to
lane-wise operations.

### 2. 904 x87 instructions across 28 mnemonics lifted to comments

Unhandled x87 forms were emitted as `/* fdivr */`-style comments, so the FPU
stack silently desynchronized from that point on. The reverse forms are the
dangerous ones: `fdivr` against 1.0 is a reciprocal, and dropping it turns a
vector normalize `v/len` into `v*len`.

### 3. `FNSTCW` / `FNSTSW` were comments only

No control or status word existed, so `_control87` could not read back rounding
or precision mode, and every `fcom`-derived parity test read a hardcoded
`true` — **1,326 sites**. The lifter now models both words, and x87 state is
preserved across calls rather than being reset per function.

## Changes

- `tools/recomp/lifter.py` — packed SSE, reverse x87 forms, control/status words.
- `tools/recomp/translator.py` — emit the wider XMM and x87 state.
- `templates/runtime/recomp_types.h` — 16-byte XMM union, x87 control/status.
- `templates/new-game/src/main.c` — initialize the new state.
- `tools/recomp/test_lifter_sse.py`, `test_lifter_fpu.py`,
  `test_lifter_fpu_reverse.py` — new, 42 tests.

## Testing

`pytest tools/recomp` — 42 new tests pass. Full toolchain with
`--ignore=tools/symbols` (pre-existing failure on `main`).

This is the largest of the four branches (+793/−63). It's split from the others
so the SSE/x87 modeling can be reviewed on its own; it does not depend on #1,
#2, or #4.

Validated against a private commercial title, hence instruction-class counts
rather than game specifics.
