### PR TITLE
Integrate the community PRs (#6-#10), credit the contributors, and ship the LGPL text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,16 @@ Every Xbox game has its own asset formats. If you reverse-engineer a texture for
 
 ## Testing
 
-There is no automated test suite (yet). Testing is manual:
+The Python side of the toolchain has a test suite. Run it before opening a PR:
+
+```
+py -3 -m pytest tools/
+```
+
+It is fast and needs no game files — the lifter tests assemble real byte
+sequences and check the C that comes out. If you fix a lift, add the case.
+
+Running a game is still manual:
 
 1. Build the runtime libraries.
 2. Build a game project that uses them (Burnout 3, Wreckless, Blood Wake, or your own).
@@ -117,6 +126,19 @@ The VEH crash handler and ICALL trace ring buffer are your primary debugging too
 - **Lifter failures**: If the lifter produces incorrect C for a function, include the original disassembly and the generated C output.
 - **Pull requests**: Fork the repo, make your changes on a branch, and open a PR. Describe what you changed and which game(s) you tested with.
 
+## Credit
+
+Contributors are listed in **[CONTRIBUTORS.md](CONTRIBUTORS.md)**, and that
+includes people who only ever filed an issue. A good bug report is a
+contribution — several of the entries there are exactly that. If you land
+something and your name doesn't appear, that's our mistake: open a PR against
+the file, or just say so on the issue.
+
 ## License
 
 This project is licensed under the **MIT License**. By submitting a contribution, you agree that your work will be released under the same license.
+
+The exception is the xemu-derived code under `src/apu/` and
+`src/nv2a/nv2a_regs.h`, which is LGPL-2.1-or-later and stays that way — see
+[NOTICE](NOTICE). If you patch those files, your change is LGPL too, and the
+existing copyright headers must stay intact.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,121 @@
+# Contributors
+
+xboxrecomp exists because people who care about the Xbox keep showing up.
+Thank you to everyone who has contributed code, fixes, testing, or a hard-won
+debugging insight. This file is the canonical record of who did what — the
+README changelog tells the story release-by-release, but credit lives here.
+
+Reporting a bug counts. Several of the entries below are people who never sent
+a patch and still moved the project further than a patch would have, because
+they found the wall everyone else was going to hit.
+
+If you've contributed and aren't listed, or a line here is wrong, open a PR
+against this file — we want every name right.
+
+---
+
+## Maintainer
+
+### Ned Heller — [@sp00nznet](https://github.com/sp00nznet)
+Project creator and maintainer. The x86 disassembler and lifter, XBE parsing,
+the kernel/XAPI runtime and HLE layer, the D3D8 and NV2A translation, the XISO
+and XMV tooling, and the recompilation pipeline that ties them together.
+
+---
+
+## Contributors
+
+### NoRain211 — [@NoRain211](https://github.com/NoRain211)
+A correctness batch across the disassembler, lifter and translator, found by
+stress-testing the pipeline against a real title. Almost all of it is the
+dangerous kind of bug: the generated C compiles, links, runs, and is quietly
+wrong, with no lifter error or warning anywhere.
+
+*Control-flow recovery (#7)*
+- **Conditional tail calls skipped the frame bridge** — `jcc` to a known
+  function entry is a tail call, but only the unconditional form emitted the
+  bridge, so the taken edge jumped into the callee with the caller's frame
+  still live. 8,263 call sites across 5,426 functions on the title tested.
+- **Fall-through off the end of a function emitted nothing** — a block running
+  off its own end into the next function produced no transfer at all; control
+  fell out of the generated switch and returned. 3,183 sites.
+- **Indirect calls read the target after the return-address push** — `call
+  [esp+X]` computed its operand once `esp` had already moved, so the target
+  came from the wrong slot. The operand is now snapshotted before the push.
+- **Computed jump targets were not owned by the enclosing function**, and
+  `--seed-functions` can now be repeated to merge several seed sets.
+
+*Flag computation (#8)*
+- **`repe cmpsb` / `repne scasb` folded their result flags to a literal 1**, so
+  every `memcmp`/`strcmp`-shaped loop in the CRT reported "equal" regardless of
+  input. ZF/CF now derive from the last pair actually compared.
+- **`NEG` carry was lost before a dependent `SBB`/`ADC`** — CF was preserved
+  only when the consumer was the very next instruction, but real codegen
+  separates them with flag-safe instructions, and the borrow silently went to
+  zero. That is the standard 64-bit subtract and sign-extend idiom, so the
+  corruption lands squarely in integer math.
+- **Signed compares were evaluated at 32 bits regardless of operand width**, so
+  `cmp al, bl` + `jl` never had the sign bit in the right place.
+
+*x87 and SSE (#9, #10)*
+- **Packed SSE was lifted as a scalar `float`** — XMM was modelled as a single
+  float, so `movaps`/`movups` transferred 4 of 16 bytes and silently discarded
+  the upper three lanes (18,439 moves), and packed arithmetic had no pattern at
+  all: 561 operations dropped outright.
+- **904 x87 instructions across 28 mnemonics lifted to comments**, desynchro-
+  nising the FPU stack from that point on. The reverse forms are the nastiest —
+  `fdivr` against 1.0 is a reciprocal, and dropping it turns a vector normalise
+  `v/len` into `v*len`.
+- **`FNSTCW` / `FNSTSW` were comments only**, so `_control87` could not read
+  back rounding or precision mode and every `fcom`-derived parity test read a
+  hardcoded `true` (1,326 sites). Both words are now modelled, and x87 state is
+  shared rather than reset per function.
+- **XMM was declared as a C local in each generated function**, so a value
+  written in one lifted block and read in the next was lost to a fresh zeroed
+  local. It is guest state now.
+
+*(The runtime half of the SSE work — the `RecompXmm` union and the 28 `XMM_*`
+helpers the lift emits — was not in the PRs and was added on integration.)*
+
+### DarthSidious666 — [@DarthSidious666](https://github.com/DarthSidious666)
+- **Implemented the missing `tools/abi_analysis` (#6)** — the pipeline had a
+  hole in it: `tools.recomp` looked for `abi_functions.json`, warned when it
+  was absent, and then fell back to `cdecl` / 0 params / `int_or_void` for
+  every single function, because the tool that was supposed to produce that
+  file did not exist. Recovers calling convention (including thiscall from
+  ecx-read-before-write), parameter count from the `ret` immediate, return-type
+  hints and frame shape, so the generated signatures are real.
+- Also **diagnosed the tail of issue #2**, narrowing it from "recomp crashes"
+  to the specific missing tool, and posted a workaround before the PR.
+
+---
+
+## Issue reports and testing
+
+### Tiptup300 — [@Tiptup300](https://github.com/Tiptup300)
+- **Found that every documented step of the getting-started guide was broken
+  (#1)** — and found it on Linux, which is not the platform any of it had been
+  tried on. The report walked the whole pipeline: `tools.xbe_parser` not being
+  runnable as a module, step 2 never emitting the JSON that step 3 requires,
+  the ABI file that does not exist, and the crash at the end of `tools.recomp`.
+  That single issue is the origin of the pipeline fix in `21488f4` — and of the
+  repository having a LICENSE file at all, which the README had claimed for
+  months without one actually existing.
+
+### M0RSM4LLEO — [@M0RSM4LLEO](https://github.com/M0RSM4LLEO)
+- **Reproduced and pinned down the getting-started failures (#2)** with the
+  kind of detail that makes a report actionable: exact commands, exact
+  tracebacks, tool versions, and the observation that `tools/xbe_parser` was
+  the only tool package with no `__main__.py` while every other one had it.
+  Kept testing through each fix and reported what broke next, which is how the
+  `write_summary` crash at the very end of a full run got found.
+
+---
+
+## A note on AI-assisted contributions
+
+Parts of this project — and some contributions to it — were developed with the
+help of AI coding tools. That's welcome here: what matters is that every change
+is understood, reviewed, and verified by a human before it lands. If you used
+an assistant, just say so in your PR (several contributors have) and make sure
+you can stand behind the result.

--- a/LICENSES/LGPL-2.1.txt
+++ b/LICENSES/LGPL-2.1.txt
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,12 @@
+# Third-party licence texts
+
+`LGPL-2.1.txt` is the verbatim GNU Lesser General Public License v2.1, from
+
+    https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+
+It applies to the files listed under "LGPL-2.1-or-later" in the top-level
+NOTICE — the MCPX APU sources and `src/nv2a/nv2a_regs.h`, extracted from xemu
+and remaining the copyright of espes, Jannik Vogel and Matt Borgerson.
+
+Shipping the verbatim text alongside those files is an LGPL requirement, not
+a courtesy.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,80 @@
+xboxrecomp — third-party attribution
+====================================
+
+xboxrecomp is MIT licensed (see LICENSE). The components listed below are
+not, and are included here under their original licences with their original
+copyright intact. They are other people's work and are credited as such.
+
+
+LGPL-2.1-or-later — extracted from xemu
+---------------------------------------
+
+  https://github.com/xemu-project/xemu
+
+  Files, with the copyright each one carries:
+
+    src/apu/apu_core.c    MCPX APU core
+                          (c) 2012 espes; 2018-2019 Jannik Vogel;
+                          2019-2025 Matt Borgerson
+    src/apu/apu_dsp.c     MCPX APU DSP (GP/EP)
+                          (c) 2012 espes; 2019-2025 Matt Borgerson
+    src/apu/apu_vp.c      MCPX APU voice processor
+                          (c) 2012 espes; 2018-2019 Jannik Vogel;
+                          2019-2025 Matt Borgerson
+    src/apu/apu_regs.h    (c) 2012 espes; 2018-2019 Jannik Vogel;
+                          2019-2021 Matt Borgerson
+    src/apu/apu_state.h   (c) 2012 espes; 2018-2019 Jannik Vogel;
+                          2019-2025 Matt Borgerson
+    src/apu/apu_debug.h   (c) 2020-2021 Matt Borgerson
+    src/apu/fpconv.h      (c) 2020-2025 Matt Borgerson
+    src/nv2a/nv2a_regs.h  NV2A register definitions
+                          (c) 2012 espes; 2015 Jannik Vogel
+
+  src/apu/apu_shim.h is this project's own file but is released under the
+  same licence, because it exists only to host the extracted APU code.
+
+  Licensed under the GNU Lesser General Public License, version 2.1 or (at
+  your option) any later version. The full text is in LICENSES/LGPL-2.1.txt;
+  the canonical copy is
+  https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt
+
+  These files keep their own licence. Linking against them from MIT or
+  proprietary code is expressly permitted by the LGPL — that is what
+  distinguishes it from the GPL. What the LGPL asks in return is that the
+  notices stay, that the source stays available, and that a user can relink
+  against a modified version. Distributing this repository, source included,
+  satisfies that.
+
+
+Derived algorithms — credited, independently implemented
+--------------------------------------------------------
+
+  src/d3d/d3d8_swizzle.h
+    Implements Xbox Z-order (Morton) texture unswizzling. The
+    masked-increment technique is Fabian Giesen's, published on his blog;
+    xemu's hw/xbox/nv2a/pgraph/swizzle.c is cited in the file as the
+    reference that pointed us at it.
+
+  src/d3d/d3d8_combiners.h
+    NV2A register-combiner translation. Cites xemu's pgraph combiner
+    implementation as a reference for the hardware's behaviour.
+
+  Algorithms and hardware behaviour are not themselves copyrightable, and
+  these are our own implementations. They are listed here because the debt is
+  real and should be visible even where no licence obligation attaches. If
+  anyone believes either file crosses from "implements the same algorithm"
+  into "copies the expression", raise an issue and we will rewrite or
+  relicense it — getting the credit right matters more to us than the licence
+  label.
+
+
+Reference material (no code taken)
+-----------------------------------
+
+  xemu, Cxbx-Reloaded and xboxdevwiki were used as references for hardware
+  behaviour: register offsets, kernel export ordinals, structure layouts.
+  Those are functional facts rather than expression, and no code was copied
+  for them.
+
+
+Contributors to xboxrecomp itself are credited in CONTRIBUTORS.md.

--- a/README.md
+++ b/README.md
@@ -439,11 +439,37 @@ A: C is portable, debuggable, and the compiler optimizes it for you. You can rea
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).
+
+Two subsystems are not MIT and are not ours: the MCPX APU sources under
+`src/apu/` and `src/nv2a/nv2a_regs.h` were extracted from
+[xemu](https://github.com/xemu-project/xemu) and remain LGPL-2.1-or-later,
+copyright espes, Jannik Vogel and Matt Borgerson. They keep their own licence
+and their own notices. [NOTICE](NOTICE) lists every such file with the
+copyright it carries, and [LICENSES/LGPL-2.1.txt](LICENSES/LGPL-2.1.txt) is
+the verbatim licence text — shipping it alongside those files is an LGPL
+requirement, not a courtesy.
+
+The LGPL expressly permits linking from MIT or proprietary code; that is what
+distinguishes it from the GPL. What it asks in return is that the notices
+stay, the source stays available, and a user can relink against a modified
+version. Distributing this repository, source included, satisfies that.
+
+## Contributors
+
+xboxrecomp is built by more than one person. See
+**[CONTRIBUTORS.md](CONTRIBUTORS.md)** for who did what — including the people
+who never sent a patch and still moved the project further than a patch would
+have, by finding the wall everyone else was about to hit.
+
+Thank you, all of you.
 
 ## Credits
 
 Built with [Claude Code](https://claude.ai) (Anthropic) — proving that AI-assisted systems programming can tackle problems previously considered impractical.
+
+Human contributors are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md); the
+third-party code we build on is credited in [NOTICE](NOTICE).
 
 ## References
 

--- a/templates/new-game/src/main.c
+++ b/templates/new-game/src/main.c
@@ -60,6 +60,11 @@ uint32_t g_fp_top;
 /* x87 reset default: all exceptions masked, round to nearest. */
 uint16_t g_fp_control_word = 0x037fu;
 int g_fp_cmp;
+/* SSE state. Global for the same reason the volatile GPRs are: one guest
+ * routine can lift to several C functions, and a value written in one
+ * body is read in the next. */
+RecompXmm g_xmm0, g_xmm1, g_xmm2, g_xmm3;
+RecompXmm g_xmm4, g_xmm5, g_xmm6, g_xmm7;
 extern ptrdiff_t g_xbox_mem_offset;
 
 /* ── XBE Constants ─────────────────────────────────────────── */

--- a/templates/new-game/src/main.c
+++ b/templates/new-game/src/main.c
@@ -55,6 +55,8 @@
 extern uint32_t g_eax, g_ecx, g_edx, g_esp;
 extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
+double g_fp_stack[8];
+uint32_t g_fp_top;
 extern ptrdiff_t g_xbox_mem_offset;
 
 /* ── XBE Constants ─────────────────────────────────────────── */

--- a/templates/new-game/src/main.c
+++ b/templates/new-game/src/main.c
@@ -57,6 +57,9 @@ extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
 double g_fp_stack[8];
 uint32_t g_fp_top;
+/* x87 reset default: all exceptions masked, round to nearest. */
+uint16_t g_fp_control_word = 0x037fu;
+int g_fp_cmp;
 extern ptrdiff_t g_xbox_mem_offset;
 
 /* ── XBE Constants ─────────────────────────────────────────── */

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -102,6 +102,17 @@ extern uint32_t g_ebx, g_esi, g_edi;
 extern uint32_t g_seh_ebp;
 extern double g_fp_stack[8];
 extern uint32_t g_fp_top;
+extern uint16_t g_fp_control_word;
+/* Result of the last x87 compare: -1, 0, or 1. One guest routine can lift
+   to several C functions, so a compare and the FNSTSW that reads it can
+   land in different bodies; the hardware status word is shared too. */
+extern int g_fp_cmp;
+
+/* x86 PF: set when the low byte of the result has an even number of set
+   bits. Used by FNSTSW/TEST AH parity branches. */
+#define PARITY8(value) \
+    ((((0x9669u >> (((uint8_t)(value) ^ ((uint8_t)(value) >> 4)) & 0xfu)) \
+       & 1u)) != 0u)
 
 /* ================================================================
  * ICALL trace ring buffer (for debugging indirect calls)

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -168,15 +168,28 @@ void recomp_icall_fail_log(uint32_t va);
 #define CMP_A(a, b)   ((uint32_t)(a) >  (uint32_t)(b))   /* above */
 
 /* Signed comparison conditions */
-#define CMP_L(a, b)   ((int32_t)(a) <  (int32_t)(b))     /* less (SF!=OF) */
-#define CMP_GE(a, b)  ((int32_t)(a) >= (int32_t)(b))     /* greater or equal */
-#define CMP_LE(a, b)  ((int32_t)(a) <= (int32_t)(b))     /* less or equal */
-#define CMP_G(a, b)   ((int32_t)(a) >  (int32_t)(b))     /* greater */
+/* x86 evaluates the signed conditions at the operand width, not at 32 bits.
+   The generated code passes LO8/HI8/LO16 sub-register reads straight in, and
+   those zero-extend, so recover the width and sign-extend before comparing. */
+#define RECOMP_FLAG_WIDTH(a, b) (sizeof(a) < sizeof(b) ? sizeof(a) : sizeof(b))
+#define RECOMP_SIGNED(value, width) \
+    ((width) == 1u ? (int32_t)(int8_t)(uint8_t)(uint32_t)(value) \
+     : (width) == 2u ? (int32_t)(int16_t)(uint16_t)(uint32_t)(value) \
+     : (int32_t)(uint32_t)(value))
+#define CMP_L(a, b)   (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) <  \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* less */
+#define CMP_GE(a, b)  (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) >= \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* >= */
+#define CMP_LE(a, b)  (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) <= \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* <= */
+#define CMP_G(a, b)   (RECOMP_SIGNED(a, RECOMP_FLAG_WIDTH(a, b)) >  \
+                       RECOMP_SIGNED(b, RECOMP_FLAG_WIDTH(a, b)))  /* > */
 
 /* TEST-based conditions (AND without storing result) */
 #define TEST_Z(a, b)  (((uint32_t)(a) & (uint32_t)(b)) == 0)  /* ZF=1 */
 #define TEST_NZ(a, b) (((uint32_t)(a) & (uint32_t)(b)) != 0)  /* ZF=0 */
-#define TEST_S(a, b)  ((int32_t)((uint32_t)(a) & (uint32_t)(b)) < 0) /* SF=1 */
+#define TEST_S(a, b)  (RECOMP_SIGNED((uint32_t)(a) & (uint32_t)(b), \
+                                     RECOMP_FLAG_WIDTH(a, b)) < 0)  /* SF=1 */
 
 /* ================================================================
  * Arithmetic with carry/overflow detection

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -166,6 +166,168 @@ void recomp_icall_fail_log(uint32_t va);
 #define MEMD(addr)   (*(volatile double   *)XBOX_PTR(addr))
 
 /* ================================================================
+ * SSE / XMM register state
+ *
+ * XMM is 128 bits of architectural state, not a scalar float. Modelling
+ * it as a `float` made movaps/movups transfer 4 of 16 bytes and silently
+ * drop the upper three lanes, and left the packed arithmetic with no
+ * representation at all.
+ *
+ * The registers are global for the same reason the volatile GPRs are:
+ * one guest routine can lift to several C functions, so a value produced
+ * in one body and read in the next has to outlive the body that wrote it.
+ * A function-local declaration would also shadow these, and the local
+ * starts zeroed -- a returned float would silently read as 0.0.
+ *
+ * The helpers are lane-wise C rather than host intrinsics: the guest
+ * semantics stay explicit (MINPS returning src on unordered, CMPNEQPS
+ * being the unordered form) and the header stays portable.
+ * ================================================================ */
+
+typedef union RecompXmm {
+    float    f[4];
+    double   d[2];
+    uint32_t u[4];
+    int32_t  i[4];
+    uint64_t q[2];
+} RecompXmm;
+
+extern RecompXmm g_xmm0, g_xmm1, g_xmm2, g_xmm3;
+extern RecompXmm g_xmm4, g_xmm5, g_xmm6, g_xmm7;
+
+/* -- construction -- */
+
+static inline RecompXmm XMM_ZERO(void) {
+    RecompXmm r; r.q[0] = 0; r.q[1] = 0; return r;
+}
+
+/** movss from memory: lane 0 set, upper lanes zeroed. */
+static inline RecompXmm XMM_SCALAR(float v) {
+    RecompXmm r = XMM_ZERO(); r.f[0] = v; return r;
+}
+
+/** movsd from memory: low double set, high double zeroed. */
+static inline RecompXmm XMM_SCALAR_DOUBLE(double v) {
+    RecompXmm r = XMM_ZERO(); r.d[0] = v; return r;
+}
+
+/** movd: 32 raw bits into lane 0, upper lanes zeroed. */
+static inline RecompXmm XMM_SCALAR_BITS(uint32_t bits) {
+    RecompXmm r = XMM_ZERO(); r.u[0] = bits; return r;
+}
+
+/* -- guest memory --
+ * Addresses are guest VAs, so they go through MEM32 like every other
+ * access. Done lane-wise, which is also unaligned-safe for movups. */
+
+static inline RecompXmm XMM_MEM(uint32_t addr) {
+    RecompXmm r;
+    r.u[0] = MEM32(addr);      r.u[1] = MEM32(addr + 4);
+    r.u[2] = MEM32(addr + 8);  r.u[3] = MEM32(addr + 12);
+    return r;
+}
+
+static inline void XMM_STORE(uint32_t addr, RecompXmm v) {
+    MEM32(addr)      = v.u[0]; MEM32(addr + 4)  = v.u[1];
+    MEM32(addr + 8)  = v.u[2]; MEM32(addr + 12) = v.u[3];
+}
+
+/* movlps/movhps move 8 bytes into or out of one half, leaving the
+ * other half alone. */
+#define XMM_LOAD_LOW(dst, addr)   recomp_xmm_load_half(&(dst), (addr), 0)
+#define XMM_LOAD_HIGH(dst, addr)  recomp_xmm_load_half(&(dst), (addr), 1)
+#define XMM_STORE_LOW(addr, src)  recomp_xmm_store_half((addr), (src), 0)
+#define XMM_STORE_HIGH(addr, src) recomp_xmm_store_half((addr), (src), 1)
+
+static inline void recomp_xmm_load_half(RecompXmm *dst, uint32_t addr,
+                                        int high) {
+    dst->u[high * 2]     = MEM32(addr);
+    dst->u[high * 2 + 1] = MEM32(addr + 4);
+}
+
+static inline void recomp_xmm_store_half(uint32_t addr, RecompXmm src,
+                                         int high) {
+    MEM32(addr)     = src.u[high * 2];
+    MEM32(addr + 4) = src.u[high * 2 + 1];
+}
+
+/** movlhps: dst high = src low. */
+static inline RecompXmm XMM_MOVE_LOW_TO_HIGH(RecompXmm a, RecompXmm b) {
+    RecompXmm r; r.q[0] = a.q[0]; r.q[1] = b.q[0]; return r;
+}
+
+/** movhlps: dst low = src high. */
+static inline RecompXmm XMM_MOVE_HIGH_TO_LOW(RecompXmm a, RecompXmm b) {
+    RecompXmm r; r.q[0] = b.q[1]; r.q[1] = a.q[1]; return r;
+}
+
+/* -- packed arithmetic -- */
+
+#define RECOMP_XMM_LANEWISE(name, expr)                                   \
+    static inline RecompXmm name(RecompXmm a, RecompXmm b) {              \
+        RecompXmm r; int i;                                               \
+        for (i = 0; i < 4; ++i) { (void)a; (void)b; r.f[i] = (expr); }    \
+        return r;                                                         \
+    }
+
+RECOMP_XMM_LANEWISE(XMM_ADD, a.f[i] + b.f[i])
+RECOMP_XMM_LANEWISE(XMM_SUB, a.f[i] - b.f[i])
+RECOMP_XMM_LANEWISE(XMM_MUL, a.f[i] * b.f[i])
+RECOMP_XMM_LANEWISE(XMM_DIV, a.f[i] / b.f[i])
+/* MINPS/MAXPS return the second operand when the lanes are unordered or
+ * equal -- that is the hardware's tie-break, not a C fmin/fmax. */
+RECOMP_XMM_LANEWISE(XMM_MIN, (a.f[i] < b.f[i]) ? a.f[i] : b.f[i])
+RECOMP_XMM_LANEWISE(XMM_MAX, (a.f[i] > b.f[i]) ? a.f[i] : b.f[i])
+
+#define RECOMP_XMM_BITWISE(name, expr)                                    \
+    static inline RecompXmm name(RecompXmm a, RecompXmm b) {              \
+        RecompXmm r; int i;                                               \
+        for (i = 0; i < 4; ++i) { (void)a; (void)b; r.u[i] = (expr); }    \
+        return r;                                                         \
+    }
+
+RECOMP_XMM_BITWISE(XMM_AND,  a.u[i] & b.u[i])
+RECOMP_XMM_BITWISE(XMM_OR,   a.u[i] | b.u[i])
+RECOMP_XMM_BITWISE(XMM_XOR,  a.u[i] ^ b.u[i])
+/* ANDNPS is ~dst & src, not dst & ~src. */
+RECOMP_XMM_BITWISE(XMM_ANDN, (~a.u[i]) & b.u[i])
+
+/* Compares produce an all-ones or all-zero mask per lane. EQ/LT/LE are
+ * the ordered forms (false when either lane is NaN); NEQ is the
+ * unordered form, so it is true when a lane is NaN. */
+RECOMP_XMM_BITWISE(XMM_CMP_EQ,  (a.f[i] == b.f[i]) ? 0xFFFFFFFFu : 0u)
+RECOMP_XMM_BITWISE(XMM_CMP_LT,  (a.f[i] <  b.f[i]) ? 0xFFFFFFFFu : 0u)
+RECOMP_XMM_BITWISE(XMM_CMP_LE,  (a.f[i] <= b.f[i]) ? 0xFFFFFFFFu : 0u)
+RECOMP_XMM_BITWISE(XMM_CMP_NEQ, (a.f[i] == b.f[i]) ? 0u : 0xFFFFFFFFu)
+
+/** movmskps: the four lane sign bits, packed into the low nibble. */
+static inline uint32_t XMM_MOVEMASK(RecompXmm a) {
+    return ((a.u[0] >> 31) & 1u) | (((a.u[1] >> 31) & 1u) << 1)
+         | (((a.u[2] >> 31) & 1u) << 2) | (((a.u[3] >> 31) & 1u) << 3);
+}
+
+/** shufps: lanes 0-1 selected out of `a`, lanes 2-3 out of `b`. */
+static inline RecompXmm XMM_SHUFFLE(RecompXmm a, RecompXmm b, uint32_t imm) {
+    RecompXmm r;
+    r.u[0] = a.u[(imm >> 0) & 3u]; r.u[1] = a.u[(imm >> 2) & 3u];
+    r.u[2] = b.u[(imm >> 4) & 3u]; r.u[3] = b.u[(imm >> 6) & 3u];
+    return r;
+}
+
+/** unpcklps / unpckhps: interleave the low or high halves. */
+static inline RecompXmm XMM_UNPACK_LOW(RecompXmm a, RecompXmm b) {
+    RecompXmm r;
+    r.u[0] = a.u[0]; r.u[1] = b.u[0]; r.u[2] = a.u[1]; r.u[3] = b.u[1];
+    return r;
+}
+
+static inline RecompXmm XMM_UNPACK_HIGH(RecompXmm a, RecompXmm b) {
+    RecompXmm r;
+    r.u[0] = a.u[2]; r.u[1] = b.u[2]; r.u[2] = a.u[3]; r.u[3] = b.u[3];
+    return r;
+}
+
+/* ================================================================
  * Flag computation helpers
  *
  * These macros compute x86 flags for conditional branches.
@@ -435,6 +597,14 @@ recomp_func_t recomp_lookup_manual(uint32_t xbox_va);
 #define ebx g_ebx
 #define esi g_esi
 #define edi g_edi
+#define xmm0 g_xmm0
+#define xmm1 g_xmm1
+#define xmm2 g_xmm2
+#define xmm3 g_xmm3
+#define xmm4 g_xmm4
+#define xmm5 g_xmm5
+#define xmm6 g_xmm6
+#define xmm7 g_xmm7
 /* ebp is NOT global - it's local in each function.
  * For __SEH_prolog/epilog, use g_seh_ebp to bridge. */
 #endif

--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -100,6 +100,8 @@ extern uint32_t g_ebx, g_esi, g_edi;
  * Similarly, __SEH_epilog reads g_seh_ebp at entry and writes it at exit.
  */
 extern uint32_t g_seh_ebp;
+extern double g_fp_stack[8];
+extern uint32_t g_fp_top;
 
 /* ================================================================
  * ICALL trace ring buffer (for debugging indirect calls)
@@ -146,6 +148,7 @@ void recomp_icall_fail_log(uint32_t va);
 #define SMEM8(addr)  (*(volatile int8_t   *)XBOX_PTR(addr))
 #define SMEM16(addr) (*(volatile int16_t  *)XBOX_PTR(addr))
 #define SMEM32(addr) (*(volatile int32_t  *)XBOX_PTR(addr))
+#define SMEM64(addr) (*(volatile int64_t  *)XBOX_PTR(addr))
 
 /** Float/double memory access. */
 #define MEMF(addr)   (*(volatile float    *)XBOX_PTR(addr))

--- a/tools/abi_analysis/__main__.py
+++ b/tools/abi_analysis/__main__.py
@@ -1,0 +1,144 @@
+"""
+tools/abi_analysis/__main__.py
+
+Recovers calling-convention / parameter-count / return-type / frame-shape
+info for every recompiled function, so tools.recomp can generate more
+accurate C signatures instead of falling back to its cdecl/0-param/int-or-void
+defaults for everything.
+
+Usage (matches the other pipeline tools' style):
+
+    py -3 -m tools.abi_analysis game_files/default.xbe
+
+    py -3 -m tools.abi_analysis game_files/default.xbe \
+        --functions tools/disasm/output/functions.json \
+        --identified tools/func_id/output/identified_functions.json \
+        --output-dir tools/abi_analysis/output \
+        -v
+
+Writes tools/abi_analysis/output/abi_functions.json by default, which is
+exactly where tools.recomp looks for it (see tools/recomp/__main__.py's
+--abi-dir default).
+"""
+
+import argparse
+import json
+import os
+import sys
+
+from .analyzer import AbiAnalyzer
+from .xbe_min import XbeFile
+
+
+def find_data_files(disasm_dir=None, func_id_dir=None, overrides=None):
+    base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    disasm_dir = disasm_dir or os.path.join(base, "disasm", "output")
+    func_id_dir = func_id_dir or os.path.join(base, "func_id", "output")
+    paths = {
+        "functions": os.path.join(disasm_dir, "functions.json"),
+        "identified": os.path.join(func_id_dir, "identified_functions.json"),
+    }
+    overrides = overrides or {}
+    for key, val in overrides.items():
+        if val:
+            paths[key] = val
+    return paths
+
+
+def _load_json_list(path, label):
+    if not os.path.exists(path):
+        print(f"ERROR: {label} not found at {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        # Tolerate either a bare list or a {"functions": [...]} wrapper.
+        for key in ("functions", "items", "entries"):
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        # Fall back to treating dict values as the entries.
+        return list(data.values())
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.abi_analysis",
+        description="Heuristic ABI recovery (calling convention, param "
+                     "count, return type, frame shape) for recompiled "
+                     "Xbox functions.")
+    parser.add_argument("xbe_path", help="Path to default.xbe")
+    parser.add_argument("--disasm-dir",
+                         help="Directory holding tools.disasm output "
+                              "(default: tools/disasm/output)")
+    parser.add_argument("--func-id-dir",
+                         help="Directory holding tools.func_id output "
+                              "(default: tools/func_id/output)")
+    parser.add_argument("--functions",
+                         help="Path to functions.json (overrides --disasm-dir)")
+    parser.add_argument("--identified",
+                         help="Path to identified_functions.json "
+                              "(overrides --func-id-dir)")
+    parser.add_argument("--output-dir",
+                         help="Output directory (default: "
+                              "tools/abi_analysis/output)")
+    parser.add_argument("--output",
+                         help="Full output path (overrides --output-dir); "
+                              "default: <output-dir>/abi_functions.json")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.xbe_path):
+        print(f"ERROR: XBE not found at {args.xbe_path}", file=sys.stderr)
+        sys.exit(1)
+
+    paths = find_data_files(
+        disasm_dir=args.disasm_dir,
+        func_id_dir=args.func_id_dir,
+        overrides={"functions": args.functions, "identified": args.identified},
+    )
+
+    functions = _load_json_list(paths["functions"], "functions.json")
+    identified = _load_json_list(paths["identified"], "identified_functions.json")
+
+    identified_by_addr = {}
+    for entry in identified:
+        addr = entry.get("start")
+        if addr is None:
+            continue
+        addr = int(addr, 16) if isinstance(addr, str) else int(addr)
+        identified_by_addr[addr] = entry
+
+    if args.verbose:
+        print(f"Loaded {len(functions)} functions, "
+              f"{len(identified_by_addr)} classifications")
+        print(f"Loading XBE from {args.xbe_path} ...")
+
+    xbe = XbeFile(args.xbe_path)
+
+    if args.verbose:
+        print(f"XBE base=0x{xbe.base_address:08X}, "
+              f"{len(xbe.sections)} sections")
+        for s in xbe.sections:
+            print(f"  {s}")
+
+    analyzer = AbiAnalyzer(xbe, functions, identified_by_addr,
+                            verbose=args.verbose)
+    results = analyzer.analyze_all()
+
+    output_dir = args.output_dir or os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "output")
+    output_path = args.output or os.path.join(output_dir, "abi_functions.json")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2)
+
+    thiscall_count = sum(1 for r in results
+                          if r["calling_convention"].startswith("thiscall"))
+    print(f"Wrote {len(results)} ABI entries to {output_path} "
+          f"({thiscall_count} detected as thiscall)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/abi_analysis/analyzer.py
+++ b/tools/abi_analysis/analyzer.py
@@ -1,0 +1,270 @@
+"""
+tools/abi_analysis/analyzer.py
+
+Heuristic ABI recovery for statically-recompiled Xbox functions.
+
+Consumes:
+  - tools/disasm/output/functions.json      (address ranges, has_prologue, etc.)
+  - tools/func_id/output/identified_functions.json  (category classifications)
+  - the original default.xbe                (to pull raw bytes for disasm)
+
+Produces a list of dicts shaped like:
+  {
+    "address": "0x00011000",
+    "calling_convention": "cdecl" | "thiscall" | "thiscall_cdecl",
+    "estimated_params": int,
+    "return_hint": "int_or_void" | "float" | "float_sse" | "int_zero",
+    "frame_type": "fpo_leaf" | "standard_frame",
+    "stack_frame_size": int,
+    "heuristic_confidence": float,   # extra, informational only
+    "heuristic_notes": str,          # extra, informational only
+  }
+
+matching what tools/recomp/translator.py expects from abi_functions.json
+(entry["address"] parsed via int(..., 16); the "calling_convention",
+"estimated_params", "return_hint", "frame_type", "stack_frame_size" keys
+read via abi_info.get(...) with the same fallback defaults used here).
+
+Every heuristic falls back to recomp's own defaults (cdecl / 0 params /
+int_or_void / fpo_leaf / 0) whenever confidence is low, so a bad guess is
+never worse than the current "no ABI data" behavior.
+"""
+
+try:
+    from capstone import Cs, CS_ARCH_X86, CS_MODE_32
+except ImportError as e:
+    raise ImportError(
+        "capstone is required for tools.abi_analysis (pip install capstone)"
+    ) from e
+
+
+VTABLE_CATEGORY_HINTS = ("vtable", "method", "virtual")
+
+# Categories we should NOT try to guess thiscall for, even if ecx looks
+# read-before-write - these are well-known non-C++-method categories where
+# ecx-as-first-read is more likely coincidental (e.g. CRT helpers that use
+# ecx as a scratch/loop register early on).
+NON_METHOD_CATEGORY_HINTS = ("crt", "kernel", "import", "thunk")
+
+
+def _parse_int_field(entry, *keys):
+    for k in keys:
+        if k in entry and entry[k] is not None:
+            v = entry[k]
+            if isinstance(v, str):
+                return int(v, 16) if v.lower().startswith("0x") else int(v)
+            return int(v)
+    return None
+
+
+def _looks_like_method_category(category):
+    if not category:
+        return False
+    cat = category.lower()
+    if any(h in cat for h in NON_METHOD_CATEGORY_HINTS):
+        return False
+    return any(h in cat for h in VTABLE_CATEGORY_HINTS)
+
+
+class AbiAnalyzer:
+    def __init__(self, xbe, functions, identified_by_addr, verbose=False):
+        """
+        xbe: xbe_min.XbeFile
+        functions: list of function dicts from disasm's functions.json
+        identified_by_addr: dict[int addr] -> func_id entry (for category)
+        """
+        self.xbe = xbe
+        self.functions = functions
+        self.identified_by_addr = identified_by_addr
+        self.verbose = verbose
+        self.md = Cs(CS_ARCH_X86, CS_MODE_32)
+        self.md.detail = False
+
+    def analyze_all(self):
+        results = []
+        skipped = 0
+        for func in self.functions:
+            entry = self._analyze_one(func)
+            if entry is None:
+                skipped += 1
+                continue
+            results.append(entry)
+        if self.verbose:
+            print(f"abi_analysis: analyzed {len(results)} functions, "
+                  f"skipped {skipped} (no readable bytes)")
+        return results
+
+    def _analyze_one(self, func):
+        start = _parse_int_field(func, "start", "address", "addr")
+        end = _parse_int_field(func, "end")
+        size = func.get("size")
+        if start is None:
+            return None
+        if size is None:
+            size = (end - start) if end is not None else 0
+        if size <= 0:
+            return None
+
+        section_hint = func.get("section")
+        raw = self.xbe.read_bytes_at_va(start, size, name_hint=section_hint)
+        if not raw:
+            return None
+
+        try:
+            insns = list(self.md.disasm(raw, start))
+        except Exception:
+            return None
+        if not insns:
+            return None
+
+        classification = self.identified_by_addr.get(start)
+        category = classification.get("category") if classification else None
+
+        cc, this_confident = self._detect_calling_convention(insns, category)
+        ret_imm = self._find_ret_immediate(insns)
+        params = self._estimate_params(insns, ret_imm, cc)
+        return_hint = self._detect_return_hint(insns)
+        frame_type, frame_size = self._detect_frame(func, insns)
+
+        confidence = 0.5
+        notes = []
+        if this_confident:
+            confidence += 0.25
+            notes.append("ecx-read-before-write + vtable category")
+        if ret_imm is not None:
+            confidence += 0.15
+            notes.append(f"ret cleaned {ret_imm} bytes")
+        if not notes:
+            notes.append("low-confidence default")
+
+        return {
+            "address": f"0x{start:08X}",
+            "calling_convention": cc,
+            "estimated_params": params,
+            "return_hint": return_hint,
+            "frame_type": frame_type,
+            "stack_frame_size": frame_size,
+            "heuristic_confidence": round(min(confidence, 1.0), 2),
+            "heuristic_notes": "; ".join(notes),
+        }
+
+    # ------------------------------------------------------------------
+    # Heuristics
+    # ------------------------------------------------------------------
+
+    def _detect_calling_convention(self, insns, category):
+        """
+        thiscall detection: ecx is read before it is ever written within
+        the function body, AND func_id's classification suggests this is a
+        C++ method (vtable-dispatched). Both signals required to keep the
+        false-positive rate low; MSVC thiscall passes `this` in ecx and the
+        callee typically uses it (member access) before clobbering it.
+        """
+        if not _looks_like_method_category(category):
+            return "cdecl", False
+
+        ecx_read_before_write = None
+        for insn in insns:
+            op = insn.op_str.replace(" ", "")
+            is_write_ecx = insn.mnemonic in ("mov", "lea", "pop", "xor") and \
+                op.startswith("ecx,")
+            is_pure_ecx_write = insn.mnemonic == "xor" and op == "ecx,ecx"
+            reads_ecx = "ecx" in op and not op.startswith("ecx,")
+            # xor ecx,ecx both reads and writes ecx as a zero-idiom; treat
+            # as a write, not evidence of "this" usage.
+            if is_pure_ecx_write:
+                ecx_read_before_write = False
+                break
+            if is_write_ecx:
+                ecx_read_before_write = False
+                break
+            if reads_ecx:
+                ecx_read_before_write = True
+                break
+        if ecx_read_before_write:
+            return "thiscall", True
+        return "cdecl", False
+
+    def _find_ret_immediate(self, insns):
+        for insn in reversed(insns):
+            if insn.mnemonic == "ret":
+                op = insn.op_str.strip()
+                if not op:
+                    return None
+                try:
+                    return int(op, 16) if op.lower().startswith("0x") else int(op)
+                except ValueError:
+                    return None
+        return None
+
+    def _estimate_params(self, insns, ret_imm, cc):
+        if ret_imm is not None:
+            return max(0, ret_imm // 4)
+        # Fallback: scan for the highest [ebp+N] stack-argument offset.
+        # ebp+4 is the return address, ebp+8 is the first argument.
+        max_off = 0
+        for insn in insns:
+            op = insn.op_str
+            if "ebp+" not in op and "ebp +" not in op:
+                continue
+            idx = op.find("ebp+")
+            if idx == -1:
+                idx = op.find("ebp +")
+                if idx == -1:
+                    continue
+                idx += 1  # skip the space variant consistently
+            frag = op[idx + 4:]
+            digits = ""
+            for ch in frag:
+                if ch in "0123456789abcdefABCDEFx":
+                    digits += ch
+                else:
+                    break
+            if not digits:
+                continue
+            try:
+                off = int(digits, 16) if "x" in digits.lower() or any(
+                    c in "abcdefABCDEF" for c in digits) else int(digits)
+            except ValueError:
+                continue
+            if off > max_off:
+                max_off = off
+        if max_off >= 8:
+            return max(0, (max_off - 4) // 4)
+        return 0
+
+    def _detect_return_hint(self, insns):
+        # Look at the tail of the function (last few insns before the
+        # final ret) for float-return or zero-return idioms.
+        tail = insns[-4:] if len(insns) >= 4 else insns
+        for insn in tail:
+            if insn.mnemonic.startswith("fstp"):
+                return "float_sse"
+        for i, insn in enumerate(tail):
+            if insn.mnemonic == "xor" and insn.op_str.replace(" ", "") == "eax,eax":
+                # Only counts if this is the last substantive insn before ret
+                rest = tail[i + 1:]
+                if all(r.mnemonic in ("ret", "nop") for r in rest):
+                    return "int_zero"
+        return "int_or_void"
+
+    def _detect_frame(self, func, insns):
+        has_prologue = func.get("has_prologue", False)
+        if not has_prologue:
+            return "fpo_leaf", 0
+        frame_size = 0
+        # Standard prologue: push ebp; mov ebp, esp; [sub esp, N]
+        for i in range(min(len(insns), 4) - 2):
+            if (insns[i].mnemonic == "push" and insns[i].op_str == "ebp" and
+                    insns[i + 1].mnemonic == "mov" and
+                    insns[i + 1].op_str.replace(" ", "") == "ebp,esp"):
+                nxt = insns[i + 2]
+                if nxt.mnemonic == "sub" and nxt.op_str.startswith("esp,"):
+                    imm = nxt.op_str.split(",", 1)[1].strip()
+                    try:
+                        frame_size = int(imm, 16) if imm.lower().startswith("0x") \
+                            else int(imm)
+                    except ValueError:
+                        frame_size = 0
+                break
+        return "standard_frame", frame_size

--- a/tools/abi_analysis/xbe_min.py
+++ b/tools/abi_analysis/xbe_min.py
@@ -1,0 +1,130 @@
+"""
+tools/abi_analysis/xbe_min.py
+
+Minimal, dependency-free XBE header + section table reader.
+
+Only implements what abi_analysis needs: mapping a function's Xbox virtual
+address to a file offset so its raw bytes can be pulled out and disassembled.
+Based on the public XBE file format (see docs/formats/xbe.md / xboxdevwiki).
+
+This intentionally does NOT try to be a full XBE parser (no cert parsing,
+no import table, no TLS, no logo bitmap, etc.) - just headers + sections.
+"""
+
+import struct
+
+
+class XbeSection:
+    __slots__ = ("name", "flags", "virtual_address", "virtual_size",
+                 "raw_address", "raw_size")
+
+    def __init__(self, name, flags, virtual_address, virtual_size,
+                 raw_address, raw_size):
+        self.name = name
+        self.flags = flags
+        self.virtual_address = virtual_address
+        self.virtual_size = virtual_size
+        self.raw_address = raw_address
+        self.raw_size = raw_size
+
+    def contains_va(self, va):
+        return self.virtual_address <= va < self.virtual_address + self.virtual_size
+
+    def __repr__(self):
+        return (f"<XbeSection {self.name!r} va=0x{self.virtual_address:08X} "
+                f"vsize=0x{self.virtual_size:X} raw=0x{self.raw_address:08X} "
+                f"rsize=0x{self.raw_size:X}>")
+
+
+class XbeFile:
+    """
+    Loads an XBE's header + section table and provides VA -> file-offset
+    mapping and raw byte reads. Keeps the whole file in memory since
+    original Xbox XBEs top out in the low tens of MB.
+    """
+
+    SECTION_HEADER_SIZE = 56
+
+    def __init__(self, path):
+        self.path = path
+        with open(path, "rb") as f:
+            self.data = f.read()
+
+        if self.data[0:4] != b"XBEH":
+            raise ValueError(f"{path}: not an XBE file (bad magic)")
+
+        # Offsets below are from the public XBE image header layout.
+        # Digital_Signature is 256 bytes starting right after the 4-byte
+        # magic, so Base_Address is at 4 + 256 = 0x104.
+        (self.base_address,) = struct.unpack_from("<I", self.data, 0x104)
+        (self.size_of_headers,) = struct.unpack_from("<I", self.data, 0x108)
+        (self.entry_point_raw,) = struct.unpack_from("<I", self.data, 0x128)
+        (self.num_sections,) = struct.unpack_from("<I", self.data, 0x11C)
+        (self.section_headers_va,) = struct.unpack_from("<I", self.data, 0x120)
+
+        self.sections = self._read_sections()
+
+    def _va_to_header_offset(self, va):
+        """
+        Only valid for addresses that live in the XBE header region itself
+        (e.g. the section header table, section name strings) - NOT for
+        addresses inside a section's own virtual range. The header region's
+        file offset 0 corresponds to virtual address `base_address`.
+        """
+        return va - self.base_address
+
+    def _read_cstring_at_va(self, va, max_len=64):
+        off = self._va_to_header_offset(va)
+        end = self.data.find(b"\x00", off, off + max_len)
+        if end == -1:
+            end = off + max_len
+        return self.data[off:end].decode("ascii", errors="replace")
+
+    def _read_sections(self):
+        sections = []
+        table_off = self._va_to_header_offset(self.section_headers_va)
+        for i in range(self.num_sections):
+            off = table_off + i * self.SECTION_HEADER_SIZE
+            (flags, virtual_address, virtual_size, raw_address, raw_size,
+             name_addr) = struct.unpack_from("<IIIIII", self.data, off)
+            name = self._read_cstring_at_va(name_addr)
+            sections.append(XbeSection(name, flags, virtual_address,
+                                        virtual_size, raw_address, raw_size))
+        return sections
+
+    def find_section(self, va, name_hint=None):
+        """
+        Find the section containing `va`. If name_hint is given (e.g. the
+        "section" field from functions.json, like ".text"), prefer an exact
+        name match among candidates that also contain the address, since
+        section virtual ranges can occasionally abut.
+        """
+        candidates = [s for s in self.sections if s.contains_va(va)]
+        if not candidates:
+            return None
+        if name_hint:
+            for s in candidates:
+                if s.name == name_hint:
+                    return s
+        return candidates[0]
+
+    def read_bytes_at_va(self, va, size, name_hint=None):
+        """
+        Read `size` raw bytes starting at virtual address `va`. Returns None
+        if the address doesn't fall in any known section, or if the read
+        would run past the section's raw (on-disk) data - which happens for
+        addresses in the tail of a section that's zero-padded in memory but
+        not backed by file bytes (bss-like tail).
+        """
+        section = self.find_section(va, name_hint)
+        if section is None:
+            return None
+        offset_in_section = va - section.virtual_address
+        if offset_in_section + size > section.raw_size:
+            # Falls into the virtual-only (zero-filled) tail of the section.
+            available = max(0, section.raw_size - offset_in_section)
+            if available <= 0:
+                return None
+            size = available
+        file_off = section.raw_address + offset_in_section
+        return self.data[file_off:file_off + size]

--- a/tools/disasm/__main__.py
+++ b/tools/disasm/__main__.py
@@ -68,17 +68,22 @@ def main():
     )
     parser.add_argument(
         "--seed-functions",
+        action="append",
         default=None,
         help="JSON file with additional function entry points to seed the detector. "
              "Format: array of objects with 'start' field (hex address string). "
-             "Use identified_functions.json from func_id to feed back vtable thunks.",
+             "May be repeated to merge seed sets.",
     )
 
     args = parser.parse_args()
 
     try:
         extra = [s.strip() for s in args.extra_sections.split(",")] if args.extra_sections else []
-        seed_funcs = _load_seed_functions(args.seed_functions) if args.seed_functions else []
+        seed_funcs = [
+            addr
+            for path in (args.seed_functions or [])
+            for addr in _load_seed_functions(path)
+        ]
         disassembler = Disassembler(
             xbe_path=args.xbe_path,
             analysis_json=args.analysis_json,

--- a/tools/recomp/disasm.py
+++ b/tools/recomp/disasm.py
@@ -144,6 +144,38 @@ class Disassembler:
         self._cs.detail = True
         _init_reg_names(self._cs)
 
+    def _decode_instruction(self, cs_insn):
+        """Convert one Capstone instruction into the translator model."""
+        insn = Instruction(
+            address=cs_insn.address,
+            size=cs_insn.size,
+            mnemonic=cs_insn.mnemonic,
+            op_str=cs_insn.op_str,
+            bytes_hex=cs_insn.bytes.hex(),
+        )
+
+        try:
+            ops = cs_insn.operands
+        except Exception:
+            ops = []
+        for cs_op in ops:
+            op = _parse_operand(self._cs, cs_op, cs_insn)
+            insn.operands.append(op)
+
+            if cs_op.type == CS_OP_IMM:
+                val = cs_op.imm & 0xFFFFFFFF
+                insn.imm_values.append(val)
+                if insn.is_call:
+                    insn.call_target = val
+                elif insn.is_branch:
+                    insn.jump_target = val
+            elif cs_op.type == CS_OP_MEM:
+                if (cs_op.mem.base == 0 and cs_op.mem.index == 0
+                        and cs_op.mem.disp != 0):
+                    insn.memory_refs.append(cs_op.mem.disp & 0xFFFFFFFF)
+
+        return insn
+
     def disassemble_function(self, raw_bytes, start_va, end_va):
         """
         Disassemble bytes for a single function.
@@ -155,37 +187,45 @@ class Disassembler:
 
         instructions = []
         for cs_insn in self._cs.disasm(raw_bytes[:size], start_va):
-            insn = Instruction(
-                address=cs_insn.address,
-                size=cs_insn.size,
-                mnemonic=cs_insn.mnemonic,
-                op_str=cs_insn.op_str,
-                bytes_hex=cs_insn.bytes.hex(),
-            )
-
-            # Parse operands (detail mode is enabled on the Cs object)
-            try:
-                ops = cs_insn.operands
-            except Exception:
-                ops = []
-            for cs_op in ops:
-                op = _parse_operand(self._cs, cs_op, cs_insn)
-                insn.operands.append(op)
-
-                if cs_op.type == CS_OP_IMM:
-                    val = cs_op.imm & 0xFFFFFFFF
-                    insn.imm_values.append(val)
-                    if insn.is_call:
-                        insn.call_target = val
-                    elif insn.is_branch:
-                        insn.jump_target = val
-                elif cs_op.type == CS_OP_MEM:
-                    if cs_op.mem.base == 0 and cs_op.mem.index == 0 and cs_op.mem.disp != 0:
-                        insn.memory_refs.append(cs_op.mem.disp & 0xFFFFFFFF)
-
-            instructions.append(insn)
+            instructions.append(self._decode_instruction(cs_insn))
 
         return instructions
+
+    def disassemble_cfg(self, raw_bytes, start_va, end_va, entry_points,
+                        stop_addresses=None):
+        """Decode reachable instruction streams from an explicit worklist."""
+        size = end_va - start_va
+        if size <= 0 or size > len(raw_bytes):
+            return []
+
+        decoded = {}
+        stop_addresses = set(stop_addresses or ())
+        worklist = list(entry_points)
+        while worklist:
+            entry = worklist.pop()
+            if not (start_va <= entry < end_va) or entry in decoded:
+                continue
+            offset = entry - start_va
+            for cs_insn in self._cs.disasm(raw_bytes[offset:size], entry):
+                if cs_insn.address != entry and cs_insn.address in stop_addresses:
+                    break
+                if cs_insn.address >= end_va or cs_insn.address in decoded:
+                    break
+                insn = self._decode_instruction(cs_insn)
+                decoded[insn.address] = insn
+
+                if (insn.is_cond_jump and insn.jump_target is not None
+                        and start_va <= insn.jump_target < end_va):
+                    worklist.append(insn.jump_target)
+                if insn.is_jump:
+                    if (insn.jump_target is not None
+                            and start_va <= insn.jump_target < end_va):
+                        worklist.append(insn.jump_target)
+                    break
+                if insn.is_ret:
+                    break
+
+        return [decoded[addr] for addr in sorted(decoded)]
 
     def build_basic_blocks(self, instructions, func_start, func_end,
                            extra_leaders=None):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -605,8 +605,10 @@ def _emit_cond_goto(cond_expr, jcc, desc, target, lifter):
     if target is None:
         return f"if ({cond_expr}) {{ /* {jcc}: {desc} - indirect */ }}"
     if lifter and lifter._is_external_target(target):
+        # Conditional tail call: same frame bridge as the unconditional tail
+        # jmp in _lift_jmp, applied only on the taken path.
         name = lifter._call_target_name(target)
-        return (f"if ({cond_expr}) {{ {name}(); return; }}"
+        return (f"if ({cond_expr}) {{ g_seh_ebp = ebp; {name}(); return; }}"
                 f" /* {jcc}: {desc} */")
     return f"if ({cond_expr}) goto loc_{target:08X}; /* {jcc}: {desc} */"
 
@@ -1293,7 +1295,7 @@ class Lifter:
             if target:
                 if self._is_external_target(target):
                     name = self._call_target_name(target)
-                    return [f"if ({cond}) {{ {name}(); return; }} /* {jcc} */"]
+                    return [f"if ({cond}) {{ g_seh_ebp = ebp; {name}(); return; }} /* {jcc} */"]
                 return [f"if ({cond}) goto loc_{target:08X}; /* {jcc} */"]
             return [f"/* {jcc} - no target */"]
 
@@ -1302,7 +1304,7 @@ class Lifter:
         if target:
             if self._is_external_target(target):
                 name = self._call_target_name(target)
-                return [f"if (_flags /* {jcc}: {desc} */) {{ {name}(); return; }}"]
+                return [f"if (_flags /* {jcc}: {desc} */) {{ g_seh_ebp = ebp; {name}(); return; }}"]
             return [f"if (_flags /* {jcc}: {desc} */) goto loc_{target:08X};"]
         return [f"/* {jcc}: {desc} - no target */"]
 

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -570,9 +570,9 @@ def _make_condition(jcc, flag_setter, flag_ops):
     # ── repe cmpsb / repne scasb: string comparison ──
     if "cmps" in flag_setter or "scas" in flag_setter:
         if jcc in ("je", "jz"):
-            return "1 /* strings matched (repe cmpsb) */", desc
+            return "(_flags != 0)", desc
         if jcc in ("jne", "jnz"):
-            return "0 /* strings differed (repe cmpsb) */", desc
+            return "(_flags == 0)", desc
         return None
 
     return None
@@ -1346,9 +1346,29 @@ class Lifter:
                 "{ uint32_t _i; for (_i = 0; _i < ecx; _i++) MEM16(edi + _i*2) = LO16(eax); }",
                 "edi += ecx * 2; ecx = 0; /* rep stosw */"
             ]
-        if "cmpsb" in m or "cmpsw" in m or "cmpsd" in m:
+        if "cmpsb" in m:
+            continue_on_equal = "repne" not in m and "repnz" not in m
+            stop_condition = "!_flags" if continue_on_equal else "_flags"
+            return [
+                "while (ecx != 0) {",
+                "    _flags = (MEM8(esi) == MEM8(edi));",
+                "    esi++; edi++; ecx--;",
+                f"    if ({stop_condition}) break;",
+                f"}} /* {m} */",
+            ]
+        if "scasb" in m:
+            continue_on_equal = "repne" not in m and "repnz" not in m
+            stop_condition = "!_flags" if continue_on_equal else "_flags"
+            return [
+                "while (ecx != 0) {",
+                "    _flags = (LO8(eax) == MEM8(edi));",
+                "    edi++; ecx--;",
+                f"    if ({stop_condition}) break;",
+                f"}} /* {m} */",
+            ]
+        if "cmpsw" in m or "cmpsd" in m:
             return [f"/* {m} - string compare, ecx iterations */"]
-        if "scasb" in m or "scasw" in m or "scasd" in m:
+        if "scasw" in m or "scasd" in m:
             return [f"/* {m} - string scan, ecx iterations */"]
         return [f"/* {m} */"]
 
@@ -1778,10 +1798,10 @@ def lift_basic_block(lifter, bb, flag_state=None):
             # repe cmpsb/repne scasb = comparison, sets flags
             rest = curr.op_str.strip() if hasattr(curr, 'op_str') else ""
             raw_m = curr.mnemonic
-            if "cmps" in raw_m or "scas" in raw_m:
+            if "cmpsb" in raw_m or "scasb" in raw_m:
                 last_flag_setter = raw_m
                 last_flag_ops = list(curr.operands)
-            elif "cmps" in rest or "scas" in rest:
+            elif "cmpsb" in rest or "scasb" in rest:
                 last_flag_setter = raw_m
                 last_flag_ops = list(curr.operands)
             else:

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1199,7 +1199,17 @@ class Lifter:
         elif len(ops) >= 1:
             target = _fmt_operand_read(ops[0])
             # Mark indirect calls for post-processing by _fixup_icall_esp_save
-            return [f"PUSH32(esp, 0); RECOMP_ICALL_SAFE({target}, _icall_esp); /* indirect call */"]
+            #
+            # The target is read into a local BEFORE the return-address push.
+            # On real x86 the memory operand is computed before the push, so
+            # emitting the push first shifts esp by four and every esp-relative
+            # target -- `call dword ptr [esp+8]`, the shape MSVC gives a
+            # callback invoked through a stack argument -- is read four bytes
+            # low and dispatches through the wrong slot.
+            return [f"{{ uint32_t _icall_target = {target}; "
+                    "PUSH32(esp, 0); "
+                    "RECOMP_ICALL_SAFE(_icall_target, _icall_esp); }"
+                    " /* indirect call */"]
         return ["/* call: no target */"]
 
     def _lift_ret(self, insn, ops):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1723,12 +1723,22 @@ def lift_basic_block(lifter, bb, flag_state=None):
                 i += 1
                 continue
 
-        # NEG sets CF when its operand is nonzero. Preserve that value only
-        # for the adjacent carry consumer that needs it.
-        if (curr.mnemonic == "neg" and i + 1 < len(insns)
-                and insns[i + 1].mnemonic in ("sbb", "adc")):
+        # NEG sets CF when its operand is nonzero. Preserve that value when
+        # a later SBB/ADC consumes it, skipping over EFLAGS-preserving
+        # instructions (e.g. neg eax; push edi; sbb eax, eax).
+        if curr.mnemonic == "neg":
+            j = i + 1
+            while (j < len(insns)
+                    and insns[j].mnemonic in _EFLAGS_PRESERVE
+                    and insns[j].mnemonic != "popfd"
+                    and not insns[j].is_branch
+                    and not insns[j].is_call
+                    and not insns[j].is_ret):
+                j += 1
+            preserve = (j < len(insns)
+                        and insns[j].mnemonic in ("sbb", "adc"))
             results = lifter._lift_neg(
-                curr, curr.operands, preserve_carry=True)
+                curr, curr.operands, preserve_carry=preserve)
         else:
             results = lifter.lift_instruction(insns[i])
         stmts.extend(results)

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1024,11 +1024,16 @@ class Lifter:
         else:
             return [_fmt_operand_write(ops[0], f"{val} {op_char} {delta}")]
 
-    def _lift_neg(self, insn, ops):
+    def _lift_neg(self, insn, ops, preserve_carry=False):
         if len(ops) < 1:
             return ["/* neg: no operand */"]
         val = _fmt_operand_read(ops[0])
-        return [_fmt_operand_write(ops[0], f"(uint32_t)(-(int32_t){val})")]
+        statements = []
+        if preserve_carry:
+            statements.append(f"_cf = ({val} != 0); /* neg carry */")
+        statements.append(
+            _fmt_operand_write(ops[0], f"(uint32_t)(-(int32_t){val})"))
+        return statements
 
     def _lift_not(self, insn, ops):
         if len(ops) < 1:
@@ -1718,8 +1723,14 @@ def lift_basic_block(lifter, bb, flag_state=None):
                 i += 1
                 continue
 
-        # Lift the instruction normally
-        results = lifter.lift_instruction(insns[i])
+        # NEG sets CF when its operand is nonzero. Preserve that value only
+        # for the adjacent carry consumer that needs it.
+        if (curr.mnemonic == "neg" and i + 1 < len(insns)
+                and insns[i + 1].mnemonic in ("sbb", "adc")):
+            results = lifter._lift_neg(
+                curr, curr.operands, preserve_carry=True)
+        else:
+            results = lifter.lift_instruction(insns[i])
         stmts.extend(results)
 
         # Track flag-setting instructions

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -750,6 +750,7 @@ class Lifter:
             seh_epilog = seh_epilog if seh_epilog is not None else found_epilog
         self.SEH_PROLOG = seh_prolog
         self.SEH_EPILOG = seh_epilog
+        self.jump_table_targets = {}
 
     def _call_target_name(self, addr):
         """Get the name for a call target address.
@@ -1248,7 +1249,9 @@ class Lifter:
         if not op.mem_disp or not (op.mem_index or op.mem_base):
             return []
         table_va = op.mem_disp
-        targets = self._read_jump_table(table_va)
+        targets = self.jump_table_targets.get(table_va)
+        if targets is None:
+            targets = self._read_jump_table(table_va)
         if not targets:
             return []
         # Check that ALL targets are within the current function

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -7,7 +7,7 @@ patterns like cmp+jcc) into C statements using the recomp_types.h macros.
 Register model:
   - eax, ebx, ecx, edx, esi, edi, ebp: uint32_t locals
   - esp: uint32_t local (stack pointer)
-  - FPU: double fp_stack[8] with fp_top index
+  - FPU: shared double g_fp_stack[8] with g_fp_top index
 
 Memory model:
   - MEM8/MEM16/MEM32 macros for memory access at flat addresses
@@ -92,7 +92,23 @@ def _mem_accessor(size):
 
 def _smem_accessor(size):
     """Return the signed MEM macro for a given operand size."""
-    return {1: "SMEM8", 2: "SMEM16", 4: "SMEM32"}.get(size, "SMEM32")
+    return {
+        1: "SMEM8", 2: "SMEM16", 4: "SMEM32", 8: "SMEM64",
+    }.get(size, "SMEM32")
+
+
+def _fmt_fpu_operand(op):
+    """Format an x87 memory or stack-register operand for reading."""
+    if op.type == "mem":
+        accessor = "MEMD" if op.mem_size == 8 else "MEMF"
+        return f"{accessor}({_fmt_mem(op)})"
+    if op.type == "reg":
+        name = op.reg or ""
+        if name == "st":
+            return "fp_st(0)"
+        if name.startswith("st(") and name.endswith(")"):
+            return f"fp_st({name[3:-1]})"
+    return None
 
 
 def _fmt_mem(op):
@@ -1555,15 +1571,18 @@ class Lifter:
                     elif ops[0].mem_size == 8:
                         return [f"fp_push(MEMD({_fmt_mem(ops[0])})); /* fld double */"]
                     return [f"fp_push(MEMF({_fmt_mem(ops[0])})); /* fld */"]
+                source = _fmt_fpu_operand(ops[0])
+                if source is not None:
+                    return [f"fp_push({source}); /* fld {insn.op_str} */"]
             return [f"/* fld {insn.op_str} */"]
 
         if m in ("fst", "fstp"):
-            pop = "p" if m == "fstp" else ""
             if len(ops) >= 1 and ops[0].type == "mem":
+                pop = " fp_pop();" if m == "fstp" else ""
                 if ops[0].mem_size == 4:
-                    return [f"MEMF({_fmt_mem(ops[0])}) = (float)fp_top(); fp_pop{pop}(); /* {m} */"]
+                    return [f"MEMF({_fmt_mem(ops[0])}) = (float)fp_top();{pop} /* {m} */"]
                 elif ops[0].mem_size == 8:
-                    return [f"MEMD({_fmt_mem(ops[0])}) = fp_top(); fp_pop{pop}(); /* {m} */"]
+                    return [f"MEMD({_fmt_mem(ops[0])}) = fp_top();{pop} /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
         if m == "fild":
@@ -1574,23 +1593,44 @@ class Lifter:
 
         if m in ("fist", "fistp"):
             if len(ops) >= 1 and ops[0].type == "mem":
-                mem_acc = _mem_accessor(ops[0].mem_size)
-                return [f"{mem_acc}({_fmt_mem(ops[0])}) = (int32_t)fp_top(); /* {m} */"]
+                size = ops[0].mem_size
+                mem_acc = _smem_accessor(size)
+                int_type = {2: "int16_t", 4: "int32_t", 8: "int64_t"}.get(
+                    size, "int32_t")
+                pop = " fp_pop();" if m == "fistp" else ""
+                return [f"{mem_acc}({_fmt_mem(ops[0])}) = "
+                        f"({int_type})llrint(fp_top());{pop} /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
         if m == "fadd":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() += {source}; /* fadd {insn.op_str} */"]
             return [f"fp_st1() += fp_top(); fp_pop(); /* fadd */"]
         if m == "faddp":
             return [f"fp_st1() += fp_top(); fp_pop(); /* faddp */"]
         if m == "fsub":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() -= {source}; /* fsub {insn.op_str} */"]
             return [f"fp_st1() -= fp_top(); fp_pop(); /* fsub */"]
         if m == "fsubp":
             return [f"fp_st1() -= fp_top(); fp_pop(); /* fsubp */"]
         if m == "fmul":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() *= {source}; /* fmul {insn.op_str} */"]
             return [f"fp_st1() *= fp_top(); fp_pop(); /* fmul */"]
         if m == "fmulp":
             return [f"fp_st1() *= fp_top(); fp_pop(); /* fmulp */"]
         if m == "fdiv":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() /= {source}; /* fdiv {insn.op_str} */"]
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdiv */"]
         if m == "fdivp":
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdivp */"]
@@ -1604,7 +1644,11 @@ class Lifter:
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):
             # Set _fpu_cmp for the fcomp/fnstsw/sahf pattern
-            return [f"_fpu_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
+            source = _fmt_fpu_operand(ops[-1]) if ops else "fp_st1()"
+            pops = 2 if m.endswith("pp") else 1 if m.endswith("p") else 0
+            pop_code = " fp_pop();" * pops
+            return [f"_fpu_cmp = (fp_top() < {source}) ? -1 : "
+                    f"(fp_top() > {source}) ? 1 : 0;{pop_code}"
                     f" /* {m} {insn.op_str} */"]
         if m in ("fcompi", "fcomip", "fucomi", "fucompi", "fucomip", "fcomi"):
             # These set EFLAGS directly (CF, ZF, PF) from FPU comparison

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -336,7 +336,9 @@ def _make_condition(jcc, flag_setter, flag_ops):
     # ── comiss/ucomiss: float comparison, sets CF/ZF/PF ──
     if flag_setter in ("comiss", "comisd", "ucomiss", "ucomisd"):
         def _sse_op(op):
-            if op.type == "reg":
+            if op.type == "reg" and op.reg and op.reg.startswith("xmm"):
+                return f"{op.reg}.f[0]"
+            elif op.type == "reg":
                 return op.reg
             elif op.type == "mem":
                 if op.mem_size == 8:
@@ -914,6 +916,7 @@ class Lifter:
 
         # ── SSE (scalar float) ──
         if m in ("movss", "movsd", "movaps", "movups", "movlps", "movhps",
+                 "movlhps", "movhlps", "movapd", "movupd",
                  "addss", "subss", "mulss", "divss", "sqrtss",
                  "addsd", "subsd", "mulsd", "divsd", "sqrtsd",
                  "minss", "maxss", "minsd", "maxsd",
@@ -921,7 +924,7 @@ class Lifter:
                  "cvtsi2ss", "cvtss2si", "cvttss2si",
                  "cvtsi2sd", "cvtsd2si", "cvttsd2si",
                  "cvtss2sd", "cvtsd2ss",
-                 "xorps", "xorpd", "andps", "orps",
+                 "xorps", "xorpd", "andps", "orps", "andnps",
                  "movd", "movq",
                  "shufps", "unpcklps", "unpckhps",
                  "addps", "subps", "mulps", "divps",
@@ -1398,10 +1401,21 @@ class Lifter:
         if nops < 1:
             return [f"/* {m}: no operands */"]
 
-        # SSE register names (xmm0-xmm7) are used as float locals
+        def _is_xmm(op):
+            return op.type == "reg" and op.reg and op.reg.startswith("xmm")
+
+        def _is_mmx(op):
+            return (op.type == "reg" and op.reg and op.reg.startswith("mm")
+                    and not op.reg.startswith("xmm"))
+
+        # ── Scalar (lane 0) access ──
+        # movss/addss/... genuinely operate on one 32-bit value, so they read
+        # and write lane 0 explicitly rather than the whole register.
         def _sse_read(op):
-            if op.type == "reg":
-                return op.reg  # xmm0, xmm1, etc.
+            if _is_xmm(op):
+                return f"{op.reg}.f[0]"
+            elif op.type == "reg":
+                return op.reg
             elif op.type == "mem":
                 if op.mem_size == 8:
                     return f"MEMD({_fmt_mem(op)})"
@@ -1411,7 +1425,9 @@ class Lifter:
             return f"/* sse_read? */"
 
         def _sse_write(op, val):
-            if op.type == "reg":
+            if _is_xmm(op):
+                return f"{op.reg}.f[0] = {val};"
+            elif op.type == "reg":
                 return f"{op.reg} = {val};"
             elif op.type == "mem":
                 if op.mem_size == 8:
@@ -1419,20 +1435,101 @@ class Lifter:
                 return f"MEMF({_fmt_mem(op)}) = {val};"
             return f"/* sse_write? */;"
 
+        # ── Packed (128-bit) access ──
+        # A whole-register read yields a RecompXmm value; a whole-register
+        # write is a statement. Memory goes through the guest translation.
+        def _packed_read(op):
+            if _is_xmm(op):
+                return op.reg
+            if op.type == "mem":
+                return f"XMM_MEM({_fmt_mem(op)})"
+            return None
+
+        def _packed_write(op, val):
+            if _is_xmm(op):
+                return f"{op.reg} = {val};"
+            if op.type == "mem":
+                return f"XMM_STORE({_fmt_mem(op)}, {val});"
+            return None
+
+        def _packed_binary(helper):
+            """dst = helper(dst, src) for a two-operand packed op."""
+            if nops < 2:
+                return None
+            a = _packed_read(ops[0])
+            b = _packed_read(ops[1])
+            if a is None or b is None:
+                return None
+            written = _packed_write(ops[0], f"{helper}({a}, {b})")
+            if written is None:
+                return None
+            return [written + f" /* {m} */"]
+
         # ── Moves ──
-        if m in ("movss", "movsd", "movaps", "movups", "movlps", "movhps"):
+        # movaps/movups move all 16 bytes. Treating them like movss was the
+        # defect that left every packed value 4 bytes wide.
+        if m in ("movaps", "movups", "movapd", "movupd"):
             if nops >= 2:
+                src = _packed_read(ops[1])
+                if src is not None:
+                    written = _packed_write(ops[0], src)
+                    if written is not None:
+                        return [written + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+
+        # movlps/movhps transfer 8 bytes into or out of one half.
+        if m in ("movlps", "movhps"):
+            half = "LOW" if m == "movlps" else "HIGH"
+            if nops >= 2:
+                if _is_xmm(ops[0]) and ops[1].type == "mem":
+                    return [f"XMM_LOAD_{half}({ops[0].reg}, "
+                            f"{_fmt_mem(ops[1])}); /* {m} */"]
+                if ops[0].type == "mem" and _is_xmm(ops[1]):
+                    return [f"XMM_STORE_{half}({_fmt_mem(ops[0])}, "
+                            f"{ops[1].reg}); /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+
+        if m in ("movlhps", "movhlps"):
+            helper = ("XMM_MOVE_LOW_TO_HIGH" if m == "movlhps"
+                      else "XMM_MOVE_HIGH_TO_LOW")
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
+
+        # movss/movsd are scalar. Loading from memory zeroes the upper lanes;
+        # a register-to-register move leaves them untouched.
+        if m in ("movss", "movsd"):
+            if nops >= 2:
+                scalar = ("XMM_SCALAR" if m == "movss"
+                          else "XMM_SCALAR_DOUBLE")
+                if _is_xmm(ops[0]) and ops[1].type == "mem":
+                    return [f"{ops[0].reg} = "
+                            f"{scalar}({_sse_read(ops[1])}); /* {m} */"]
                 src = _sse_read(ops[1])
                 return [_sse_write(ops[0], src) + f" /* {m} */"]
             return [f"/* {m} {insn.op_str} */"]
 
+        # movd moves 32 bits without converting. Into an XMM register it also
+        # zeroes the upper lanes. The generated code redefines memcpy as a
+        # guest-to-guest copy, so the bits are moved through the union instead
+        # of taking the address of a host local.
         if m == "movd":
             if nops >= 2:
-                src = _fmt_operand_read(ops[1]) if ops[1].type != "reg" or not ops[1].reg.startswith("xmm") else _sse_read(ops[1])
-                if ops[0].type == "reg" and ops[0].reg.startswith("xmm"):
-                    return [f"memcpy(&{ops[0].reg}, &{src}, 4); /* movd to xmm */"]
-                else:
-                    return [f"{_fmt_operand_write(ops[0], src)} /* movd */"]
+                if _is_xmm(ops[0]):
+                    if _is_xmm(ops[1]):
+                        src = f"{ops[1].reg}.u[0]"
+                    elif _is_mmx(ops[1]):
+                        src = f"(uint32_t){ops[1].reg}"
+                    else:
+                        src = _fmt_operand_read(ops[1])
+                    return [f"{ops[0].reg} = XMM_SCALAR_BITS({src});"
+                            " /* movd to xmm */"]
+                if _is_xmm(ops[1]):
+                    return [f"{_fmt_operand_write(ops[0], ops[1].reg + '.u[0]')}"
+                            " /* movd */"]
+                src = _fmt_operand_read(ops[1])
+                return [f"{_fmt_operand_write(ops[0], src)} /* movd */"]
             return [f"/* movd {insn.op_str} */"]
 
         # ── Arithmetic ──
@@ -1461,11 +1558,15 @@ class Lifter:
                 return [_sse_write(ops[0], f"({a} > {b} ? {a} : {b})") + f" /* {m} */"]
 
         # ── Packed arithmetic ──
+        # These used to emit a bare comment, so a matrix concatenation built
+        # from shufps + mulps + addps executed as nothing at all.
         if m in ("addps", "subps", "mulps", "divps"):
-            if nops >= 2:
-                c_op = {"addps": "+", "subps": "-", "mulps": "*", "divps": "/"}[m]
-                d, s = _sse_read(ops[0]), _sse_read(ops[1])
-                return [f"/* {m}: {d} {c_op}= {s} (packed 4xfloat) */"]
+            helper = {"addps": "XMM_ADD", "subps": "XMM_SUB",
+                      "mulps": "XMM_MUL", "divps": "XMM_DIV"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Conversions ──
         if m == "cvtsi2ss":
@@ -1495,19 +1596,31 @@ class Lifter:
                 return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} - sets EFLAGS */"]
 
         # ── Bitwise ──
+        # Done on the integer lanes: these carry sign-mask and select idioms
+        # (fabs, negate, blend) that are meaningless as float arithmetic.
         if m in ("xorps", "xorpd"):
-            if nops >= 2 and ops[0].type == "reg" and ops[1].type == "reg" and ops[0].reg == ops[1].reg:
-                return [_sse_write(ops[0], "0.0f") + f" /* {m} self = zero */"]
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} */"]
-        if m in ("andps", "orps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} */"]
+            if (nops >= 2 and _is_xmm(ops[0]) and _is_xmm(ops[1])
+                    and ops[0].reg == ops[1].reg):
+                return [f"{ops[0].reg} = XMM_ZERO(); /* {m} self = zero */"]
+            lifted = _packed_binary("XMM_XOR")
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
+        if m in ("andps", "orps", "andnps"):
+            helper = {"andps": "XMM_AND", "orps": "XMM_OR",
+                      "andnps": "XMM_ANDN"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Packed min/max ──
         if m in ("minps", "maxps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} (packed 4xfloat) */"]
+            helper = "XMM_MIN" if m == "minps" else "XMM_MAX"
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Reciprocal / rsqrt ──
         if m == "rsqrtss":
@@ -1541,13 +1654,22 @@ class Lifter:
 
         # ── Packed comparison ──
         if m in ("cmpneqps", "cmpeqps", "cmpltps", "cmpleps"):
-            if nops >= 2:
-                return [f"/* {m} {_sse_read(ops[0])}, {_sse_read(ops[1])} (packed compare) */"]
+            helper = {"cmpeqps": "XMM_CMP_EQ", "cmpltps": "XMM_CMP_LT",
+                      "cmpleps": "XMM_CMP_LE", "cmpneqps": "XMM_CMP_NEQ"}[m]
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── Move mask ──
+        # This feeds branches, so a hardcoded 0 silently picked one side.
         if m == "movmskps":
             if nops >= 2:
-                return [_fmt_operand_write(ops[0], f"0 /* movmskps {_sse_read(ops[1])} */")]
+                src = _packed_read(ops[1])
+                if src is not None:
+                    return [_fmt_operand_write(ops[0], f"XMM_MOVEMASK({src})")
+                            + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
 
         # ── MMX / integer SIMD ──
         if m in ("pand", "pandn", "por", "pxor", "pcmpgtd"):
@@ -1555,7 +1677,24 @@ class Lifter:
                 return [f"/* {m} {insn.op_str} (MMX/SIMD integer) */"]
 
         # ── Shuffle/unpack ──
-        if m in ("shufps", "unpcklps", "unpckhps"):
+        # shufps is the broadcast in every matrix concatenation.
+        if m == "shufps":
+            if nops >= 3 and ops[2].type == "imm":
+                a = _packed_read(ops[0])
+                b = _packed_read(ops[1])
+                if a is not None and b is not None:
+                    written = _packed_write(
+                        ops[0],
+                        f"XMM_SHUFFLE({a}, {b}, {_fmt_imm(ops[2].imm)})")
+                    if written is not None:
+                        return [written + f" /* {m} */"]
+            return [f"/* {m} {insn.op_str} */"]
+        if m in ("unpcklps", "unpckhps"):
+            helper = ("XMM_UNPACK_LOW" if m == "unpcklps"
+                      else "XMM_UNPACK_HIGH")
+            lifted = _packed_binary(helper)
+            if lifted is not None:
+                return lifted
             return [f"/* {m} {insn.op_str} */"]
 
         return [f"/* SSE: {m} {insn.op_str} */"]
@@ -1638,12 +1777,91 @@ class Lifter:
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdiv */"]
         if m == "fdivp":
             return [f"fp_st1() /= fp_top(); fp_pop(); /* fdivp */"]
+        # Reverse forms compute source-minus-destination, not the other way
+        # round. There was no case for them, so they fell through to the
+        # bare-comment catch-all below and executed as nothing: fdivr against
+        # the constant 1.0 is the reciprocal inside the vector-normalize
+        # helper, so dropping it turned "v / len" into "v * len".
+        if m == "fsubr":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() = {source} - fp_top();"
+                            f" /* fsubr {insn.op_str} */"]
+            return [f"fp_st1() = fp_top() - fp_st1(); fp_pop(); /* fsubr */"]
+        if m == "fsubrp":
+            return [f"fp_st1() = fp_top() - fp_st1(); fp_pop(); /* fsubrp */"]
+        if m == "fdivr":
+            if ops:
+                source = _fmt_fpu_operand(ops[-1])
+                if source is not None:
+                    return [f"fp_top() = {source} / fp_top();"
+                            f" /* fdivr {insn.op_str} */"]
+            return [f"fp_st1() = fp_top() / fp_st1(); fp_pop(); /* fdivr */"]
+        if m == "fdivrp":
+            return [f"fp_st1() = fp_top() / fp_st1(); fp_pop(); /* fdivrp */"]
+        # Integer-memory arithmetic: the operand is a signed integer in
+        # memory, converted to double before the operation.
+        if m in ("fiadd", "fisub", "fisubr", "fimul", "fidiv", "fidivr"):
+            if ops and ops[0].type == "mem":
+                smem = _smem_accessor(ops[0].mem_size)
+                source = f"(double){smem}({_fmt_mem(ops[0])})"
+                op_text = {
+                    "fiadd": f"fp_top() += {source};",
+                    "fisub": f"fp_top() -= {source};",
+                    "fisubr": f"fp_top() = {source} - fp_top();",
+                    "fimul": f"fp_top() *= {source};",
+                    "fidiv": f"fp_top() /= {source};",
+                    "fidivr": f"fp_top() = {source} / fp_top();",
+                }[m]
+                return [op_text + f" /* {m} {insn.op_str} */"]
+            return [f"/* {m} {insn.op_str} - no memory operand */"]
         if m == "fchs":
             return [f"fp_top() = -fp_top(); /* fchs */"]
         if m == "fabs":
             return [f"fp_top() = fabs(fp_top()); /* fabs */"]
         if m == "fsqrt":
             return [f"fp_top() = sqrt(fp_top()); /* fsqrt */"]
+        # Transcendentals. fpatan is the core of the atan2 helper the
+        # view-matrix path calls; dropping it left an unbalanced stack value.
+        if m == "fpatan":
+            return [f"fp_st1() = atan2(fp_st1(), fp_top()); fp_pop();"
+                    f" /* fpatan */"]
+        if m == "fsin":
+            return [f"fp_top() = sin(fp_top()); /* fsin */"]
+        if m == "fcos":
+            return [f"fp_top() = cos(fp_top()); /* fcos */"]
+        if m == "fsincos":
+            return [f"{{ double _s = sin(fp_top()); "
+                    f"fp_top() = cos(fp_top()); fp_push(_s); }} /* fsincos */"]
+        if m == "fptan":
+            return [f"fp_top() = tan(fp_top()); fp_push(1.0); /* fptan */"]
+        if m == "f2xm1":
+            return [f"fp_top() = pow(2.0, fp_top()) - 1.0; /* f2xm1 */"]
+        if m == "fyl2x":
+            return [f"fp_st1() = fp_st1() * log2(fp_top()); fp_pop();"
+                    f" /* fyl2x */"]
+        if m == "fyl2xp1":
+            return [f"fp_st1() = fp_st1() * log2(fp_top() + 1.0); fp_pop();"
+                    f" /* fyl2xp1 */"]
+        if m == "fscale":
+            return [f"fp_top() = fp_top() * pow(2.0, trunc(fp_st1()));"
+                    f" /* fscale */"]
+        if m == "frndint":
+            return [f"fp_top() = rint(fp_top()); /* frndint */"]
+        if m == "fldpi":
+            return [f"fp_push(3.14159265358979323846); /* fldpi */"]
+        if m == "fldl2e":
+            return [f"fp_push(1.44269504088896340736); /* fldl2e */"]
+        if m == "fldl2t":
+            return [f"fp_push(3.32192809488736234787); /* fldl2t */"]
+        if m == "fldlg2":
+            return [f"fp_push(0.30102999566398119521); /* fldlg2 */"]
+        if m == "fldln2":
+            return [f"fp_push(0.69314718055994530942); /* fldln2 */"]
+        if m == "ftst":
+            return [f"g_fp_cmp = (fp_top() < 0.0) ? -1 : "
+                    f"(fp_top() > 0.0) ? 1 : 0; /* ftst */"]
         if m == "fxch":
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -322,7 +322,7 @@ def _make_condition(jcc, flag_setter, flag_ops):
         }
         op = fpu_cmp_map.get(jcc)
         if op:
-            return f"(_fpu_cmp {op} 0) /* {flag_setter} */", desc
+            return f"(g_fp_cmp {op} 0) /* {flag_setter} */", desc
         if jcc == "jp":
             return "0 /* fpu: unordered/NaN */", desc
         if jcc == "jnp":
@@ -373,7 +373,8 @@ def _make_condition(jcc, flag_setter, flag_ops):
         if jcc == "jns":
             return f"((int32_t)({lhs} - {rhs}) >= 0)", desc
         if jcc in ("jp", "jnp"):
-            return f"1 /* {jcc} after cmp - parity */", desc
+            sense = "" if jcc == "jp" else "!"
+            return f"{sense}PARITY8({lhs} - {rhs})", desc
         return None
 
     # ── test: flags from (a & b), operands unchanged ──
@@ -391,7 +392,10 @@ def _make_condition(jcc, flag_setter, flag_ops):
         if jcc == "jno":
             return "1", desc
         if jcc in ("jp", "jnp"):
-            return f"1 /* {jcc} after test - parity */", desc
+            # PF is the even-parity of the low byte of the result. The CRT
+            # branches on it after FNSTSW/TEST AH, so compute it.
+            sense = "" if jcc == "jp" else "!"
+            return f"{sense}PARITY8({lhs} & {rhs})", desc
         return None
 
     # ── sub: a = a - b, flags from (a_orig - b) ──
@@ -1643,11 +1647,11 @@ class Lifter:
         if m == "fxch":
             return [f"{{ double _t = fp_top(); fp_top() = fp_st1(); fp_st1() = _t; }} /* fxch */"]
         if m in ("fcom", "fcomp", "fcompp", "fucom", "fucomp", "fucompp"):
-            # Set _fpu_cmp for the fcomp/fnstsw/sahf pattern
+            # Set g_fp_cmp for the fcomp/fnstsw/sahf pattern
             source = _fmt_fpu_operand(ops[-1]) if ops else "fp_st1()"
             pops = 2 if m.endswith("pp") else 1 if m.endswith("p") else 0
             pop_code = " fp_pop();" * pops
-            return [f"_fpu_cmp = (fp_top() < {source}) ? -1 : "
+            return [f"g_fp_cmp = (fp_top() < {source}) ? -1 : "
                     f"(fp_top() > {source}) ? 1 : 0;{pop_code}"
                     f" /* {m} {insn.op_str} */"]
         if m in ("fcompi", "fcomip", "fucomi", "fucompi", "fucomip", "fcomi"):
@@ -1655,14 +1659,40 @@ class Lifter:
             # fcompi/fucompi pop st(0) after comparing; fcomi/fucomi do not
             pops = m.endswith("pi") or m.endswith("ip")
             pop_code = " fp_pop();" if pops else ""
-            return [f"_fpu_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
+            return [f"g_fp_cmp = (fp_top() < fp_st1()) ? -1 : (fp_top() > fp_st1()) ? 1 : 0;"
                     f"{pop_code} /* {m} */"]
         if m == "fnstsw":
-            return [f"/* fnstsw {insn.op_str} - store FPU status word */"]
+            # C3/C2/C0 occupy bits 14/10/8, which land in AH as 0x40/0x04/
+            # 0x01. The CRT tests AH to classify the preceding compare, so
+            # rebuild them from g_fp_cmp instead of dropping the store.
+            status = ("(uint16_t)(g_fp_cmp < 0 ? 0x0100u :"
+                      " g_fp_cmp > 0 ? 0x0000u : 0x4000u)")
+            if ops and ops[0].type == "mem":
+                return [f"MEM16({_fmt_mem(ops[0])}) = {status};"
+                        f" /* fnstsw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [_fmt_set_reg(ops[0].reg, status)
+                        + f" /* fnstsw {insn.op_str} */"]
+            return [f"/* fnstsw {insn.op_str} - no destination operand */"]
         if m == "fnstcw":
-            return [f"/* fnstcw {insn.op_str} - store FPU control word */"]
+            # The CRT reads the control word back to decide whether an
+            # exception is masked, so it must be stored, not dropped.
+            if ops and ops[0].type == "mem":
+                return [f"MEM16({_fmt_mem(ops[0])}) = g_fp_control_word;"
+                        f" /* fnstcw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [_fmt_set_reg(ops[0].reg, "g_fp_control_word")
+                        + f" /* fnstcw {insn.op_str} */"]
+            return [f"/* fnstcw {insn.op_str} - no destination operand */"]
         if m == "fldcw":
-            return [f"/* fldcw {insn.op_str} - load FPU control word */"]
+            if ops and ops[0].type == "mem":
+                return [f"g_fp_control_word = MEM16({_fmt_mem(ops[0])});"
+                        f" /* fldcw {insn.op_str} */"]
+            if ops and ops[0].type == "reg":
+                return [f"g_fp_control_word = (uint16_t)"
+                        f"{_fmt_operand_read(ops[0])};"
+                        f" /* fldcw {insn.op_str} */"]
+            return [f"/* fldcw {insn.op_str} - no source operand */"]
         if m == "fldz":
             return [f"fp_push(0.0); /* fldz */"]
         if m == "fld1":

--- a/tools/recomp/test_lifter_carry.py
+++ b/tools/recomp/test_lifter_carry.py
@@ -1,0 +1,45 @@
+import unittest
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter, lift_basic_block
+
+
+class CarryLifterTest(unittest.TestCase):
+    def test_neg_carry_feeds_adjacent_sbb(self):
+        neg = Instruction(0, 2, "neg", "esi", "f7de")
+        neg.operands = [Operand(type="reg", reg="esi")]
+        sbb = Instruction(2, 2, "sbb", "esi, esi", "19f6")
+        sbb.operands = [
+            Operand(type="reg", reg="esi"),
+            Operand(type="reg", reg="esi"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (esi != 0);", generated)
+        self.assertIn(
+            "esi = _cf ? 0xFFFFFFFF : 0; /* sbb self (CF extend) */",
+            generated,
+        )
+
+    def test_neg_carry_feeds_adjacent_adc(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        adc = Instruction(2, 3, "adc", "edx, 0", "83d200")
+        adc.operands = [
+            Operand(type="reg", reg="edx"),
+            Operand(type="imm", imm=0),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, adc]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (eax != 0);", generated)
+        self.assertIn("edx = edx + 0 + _cf; /* adc */", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_carry.py
+++ b/tools/recomp/test_lifter_carry.py
@@ -40,6 +40,80 @@ class CarryLifterTest(unittest.TestCase):
         self.assertIn("_cf = (eax != 0);", generated)
         self.assertIn("edx = edx + 0 + _cf; /* adc */", generated)
 
+    def test_neg_carry_feeds_sbb_across_push(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        push = Instruction(2, 1, "push", "edi", "57")
+        push.operands = [Operand(type="reg", reg="edi")]
+        sbb = Instruction(3, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, push, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_cf = (eax != 0);", generated)
+        self.assertIn(
+            "eax = _cf ? 0xFFFFFFFF : 0; /* sbb self (CF extend) */",
+            generated,
+        )
+
+    def test_neg_carry_not_preserved_across_flag_setter(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        add = Instruction(2, 3, "add", "ecx, 1", "83c101")
+        add.operands = [
+            Operand(type="reg", reg="ecx"),
+            Operand(type="imm", imm=1),
+        ]
+        sbb = Instruction(5, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, add, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
+    def test_neg_carry_not_preserved_across_branch(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        jmp = Instruction(2, 2, "jmp", "0x10", "eb0c")
+        jmp.jump_target = 0x10
+        sbb = Instruction(4, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, jmp, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
+    def test_neg_carry_not_preserved_across_popfd(self):
+        neg = Instruction(0, 2, "neg", "eax", "f7d8")
+        neg.operands = [Operand(type="reg", reg="eax")]
+        popfd = Instruction(2, 1, "popfd", "", "9d")
+        sbb = Instruction(3, 2, "sbb", "eax, eax", "19c0")
+        sbb.operands = [
+            Operand(type="reg", reg="eax"),
+            Operand(type="reg", reg="eax"),
+        ]
+
+        lifted, _ = lift_basic_block(
+            Lifter(), BasicBlock(start=0, instructions=[neg, popfd, sbb]))
+        generated = "\n".join(lifted)
+
+        self.assertNotIn("_cf = (eax != 0);", generated)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/recomp/test_lifter_fpu.py
+++ b/tools/recomp/test_lifter_fpu.py
@@ -113,6 +113,54 @@ class FpuLifterTest(unittest.TestCase):
         self.assertIn("#define SMEM64(addr)", runtime_types)
         self.assertIn("double g_fp_stack[8];", main)
         self.assertIn("uint32_t g_fp_top;", main)
+        self.assertIn("extern uint16_t g_fp_control_word;", runtime_types)
+        self.assertIn("#define PARITY8(value)", runtime_types)
+        self.assertIn("uint16_t g_fp_control_word", main)
+
+    def test_control_word_store_and_load_use_shared_state(self):
+        operand = Operand(type="mem", mem_base="ebp", mem_disp=0xFFFFFFFC,
+                          mem_size=2)
+        store = Instruction(0, 3, "fnstcw", "word ptr [ebp - 4]", "")
+        store.operands = [operand]
+        load = Instruction(0, 3, "fldcw", "word ptr [ebp - 4]", "")
+        load.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["MEM16(ebp + 0xFFFFFFFCu) = g_fp_control_word;"
+             " /* fnstcw word ptr [ebp - 4] */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(load),
+            ["g_fp_control_word = MEM16(ebp + 0xFFFFFFFCu);"
+             " /* fldcw word ptr [ebp - 4] */"],
+        )
+
+    def test_status_word_store_reports_the_compare_result(self):
+        instruction = Instruction(0, 2, "fnstsw", "ax", "dfe0")
+        instruction.operands = [Operand(type="reg", reg="ax")]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        # The compare can live in a different lifted body than the FNSTSW that
+        # reads it, so the result has to be shared state, not a function local.
+        self.assertIn("g_fp_cmp", lifted[0])
+        self.assertNotIn("_fpu_cmp", lifted[0])
+        self.assertIn("0x4000u", lifted[0])
+        self.assertNotIn("/* fnstsw ax - store FPU status word */", lifted[0])
+
+    def test_compare_writes_the_shared_result(self):
+        instruction = Instruction(0, 4, "fcomp", "qword ptr [ebp + 8]", "dc5d08")
+        instruction.operands = [
+            Operand(type="mem", mem_base="ebp", mem_disp=8, mem_size=8)
+        ]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertTrue(lifted[0].startswith("g_fp_cmp ="))
+        self.assertNotIn("_fpu_cmp", lifted[0])
 
 
 if __name__ == "__main__":

--- a/tools/recomp/test_lifter_fpu.py
+++ b/tools/recomp/test_lifter_fpu.py
@@ -1,0 +1,119 @@
+import unittest
+from pathlib import Path
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter
+from .translator import FunctionTranslator
+
+
+class FpuLifterTest(unittest.TestCase):
+    def test_stack_register_load_duplicates_the_old_top(self):
+        instruction = Instruction(0, 2, "fld", "st(0)", "d9c0")
+        instruction.operands = [Operand(type="reg", reg="st(0)")]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_push(fp_st(0)); /* fld st(0) */"],
+        )
+
+    def test_fst_does_not_pop_and_fstp_does(self):
+        operand = Operand(type="mem", mem_base="esp", mem_disp=0x18,
+                          mem_size=4)
+        store = Instruction(0, 4, "fst", "dword ptr [esp + 0x18]", "")
+        store.operands = [operand]
+        store_pop = Instruction(
+            0, 4, "fstp", "dword ptr [esp + 0x18]", "")
+        store_pop.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["MEMF(esp + 0x18) = (float)fp_top(); /* fst */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(store_pop),
+            ["MEMF(esp + 0x18) = (float)fp_top(); fp_pop(); /* fstp */"],
+        )
+
+    def test_qword_integer_conversion_uses_signed_64_bit_storage(self):
+        operand = Operand(type="mem", mem_base="esp", mem_disp=0x10,
+                          mem_size=8)
+        store = Instruction(
+            0, 4, "fistp", "qword ptr [esp + 0x10]", "")
+        store.operands = [operand]
+        load = Instruction(0, 4, "fild", "qword ptr [esp + 0x10]", "")
+        load.operands = [operand]
+
+        self.assertEqual(
+            Lifter().lift_instruction(store),
+            ["SMEM64(esp + 0x10) = (int64_t)llrint(fp_top()); "
+             "fp_pop(); /* fistp */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(load),
+            ["fp_push((double)SMEM64(esp + 0x10)); /* fild */"],
+        )
+
+    def test_memory_arithmetic_updates_st0_without_popping(self):
+        instruction = Instruction(
+            0, 6, "fdiv", "dword ptr [0x00123456]", "")
+        instruction.operands = [
+            Operand(type="mem", mem_disp=0x00123456, mem_size=4),
+        ]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_top() /= MEMF(0x123456); "
+             "/* fdiv dword ptr [0x00123456] */"],
+        )
+
+    def test_register_arithmetic_updates_st0_without_popping(self):
+        instruction = Instruction(0, 2, "fmul", "st(1)", "d8c9")
+        instruction.operands = [Operand(type="reg", reg="st(1)")]
+
+        self.assertEqual(
+            Lifter().lift_instruction(instruction),
+            ["fp_top() *= fp_st(1); /* fmul st(1) */"],
+        )
+
+    def test_translated_functions_share_runtime_fpu_state(self):
+        start = 0x00010000
+        instructions = [
+            Instruction(start, 2, "fld", "st(0)", "d9c0"),
+            Instruction(start + 2, 1, "ret", "", "c3"),
+        ]
+        instructions[0].operands = [Operand(type="reg", reg="st(0)")]
+        block = BasicBlock(start=start, instructions=instructions)
+        translator = FunctionTranslator(
+            b"\0", {start: {"_addr": start, "end": start + 3}})
+        translator._read_func_bytes = lambda _start, _end: b"\xd9\xc0\xc3"
+        translator.disasm.disassemble_function = (
+            lambda _raw, _start, _end: instructions)
+        translator.disasm.build_basic_blocks = (
+            lambda _instructions, _start, _end, extra_leaders=None: [block])
+
+        generated = translator.translate_function(
+            start, {"_addr": start, "end": start + 3})
+
+        self.assertIn("g_fp_stack", generated)
+        self.assertIn("g_fp_top", generated)
+        self.assertNotIn("double _fp_stack[8]", generated)
+        self.assertNotIn("int _fp_top = 0", generated)
+
+    def test_runtime_template_exports_shared_fpu_state(self):
+        root = Path(__file__).resolve().parents[2]
+        runtime_types = (
+            root / "templates" / "runtime" / "recomp_types.h"
+        ).read_text()
+        main = (
+            root / "templates" / "new-game" / "src" / "main.c"
+        ).read_text()
+
+        self.assertIn("extern double g_fp_stack[8];", runtime_types)
+        self.assertIn("extern uint32_t g_fp_top;", runtime_types)
+        self.assertIn("#define SMEM64(addr)", runtime_types)
+        self.assertIn("double g_fp_stack[8];", main)
+        self.assertIn("uint32_t g_fp_top;", main)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_fpu_reverse.py
+++ b/tools/recomp/test_lifter_fpu_reverse.py
@@ -1,0 +1,84 @@
+"""The x87 reverse-operand, integer-memory and transcendental forms.
+
+None of these had a case in _lift_fpu, so every one of them fell through to
+the bare-comment catch-all and executed as nothing at all. The stack depth
+stayed balanced while the value did not, so the wrong number flowed forward
+silently. fdivr against the constant 1.0 is the reciprocal inside the
+vector-normalize helper, which is why the view matrix read back scaled by
+the square of its own length instead of unit-length.
+"""
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+def _mem(base=None, disp=0, size=4):
+    return Operand(type="mem", mem_base=base, mem_disp=disp, mem_size=size)
+
+
+def _lift(mnemonic, op_str, operands):
+    instruction = Instruction(0, 4, mnemonic, op_str, "")
+    instruction.operands = operands
+    return Lifter().lift_instruction(instruction)
+
+
+class FpuReverseFormTest(unittest.TestCase):
+    def test_fdivr_divides_the_operand_by_the_stack_top(self):
+        """1.0 fdivr len is the reciprocal, not len / 1.0."""
+        lifted = _lift("fdivr", "dword ptr [0x281250]", [_mem(disp=0x281250)])
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("fp_top() = MEMF(0x281250) / fp_top();", lifted[0])
+        self.assertNotIn("/* FPU:", lifted[0])
+
+    def test_fsubr_subtracts_the_stack_top_from_the_operand(self):
+        lifted = _lift("fsubr", "dword ptr [eax + 0x10]",
+                       [_mem(base="eax", disp=0x10)])
+
+        self.assertIn("fp_top() = MEMF(eax + 0x10) - fp_top();", lifted[0])
+
+    def test_reverse_pop_forms_use_the_reversed_operand_order(self):
+        self.assertIn("fp_st1() = fp_top() / fp_st1(); fp_pop();",
+                      _lift("fdivrp", "st(1)", [])[0])
+        self.assertIn("fp_st1() = fp_top() - fp_st1(); fp_pop();",
+                      _lift("fsubrp", "st(1)", [])[0])
+
+    def test_forward_forms_keep_their_original_operand_order(self):
+        """The reverse cases must not disturb the plain ones."""
+        self.assertIn("fp_top() /= MEMF(eax);",
+                      _lift("fdiv", "dword ptr [eax]", [_mem(base="eax")])[0])
+        self.assertIn("fp_top() -= MEMF(eax);",
+                      _lift("fsub", "dword ptr [eax]", [_mem(base="eax")])[0])
+
+    def test_integer_memory_operands_are_read_as_signed_integers(self):
+        lifted = _lift("fidiv", "dword ptr [esp + 8]",
+                       [_mem(base="esp", disp=8)])
+
+        self.assertIn("fp_top() /= (double)SMEM32(esp + 8);", lifted[0])
+
+        word = _lift("fisubr", "word ptr [ebx + 0xbc]",
+                     [_mem(base="ebx", disp=0xBC, size=2)])
+        self.assertIn("fp_top() = (double)SMEM16(ebx + 0xBC) - fp_top();",
+                      word[0])
+
+    def test_transcendentals_emit_statements_rather_than_comments(self):
+        for mnemonic, expected in (
+            ("fpatan", "atan2(fp_st1(), fp_top())"),
+            ("fsin", "sin(fp_top())"),
+            ("fcos", "cos(fp_top())"),
+            ("frndint", "rint(fp_top())"),
+            ("fyl2x", "log2(fp_top())"),
+        ):
+            with self.subTest(mnemonic=mnemonic):
+                lifted = _lift(mnemonic, "", [])
+                self.assertIn(expected, lifted[0])
+                self.assertNotIn("/* FPU:", lifted[0])
+
+    def test_fptan_pushes_the_implicit_one(self):
+        """FPTAN leaves tan(x) and then 1.0 on the stack."""
+        self.assertIn("fp_push(1.0);", _lift("fptan", "", [])[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_frame_bridge.py
+++ b/tools/recomp/test_lifter_frame_bridge.py
@@ -1,0 +1,45 @@
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+class FrameBridgeLifterTest(unittest.TestCase):
+    def test_register_indirect_call_snapshots_target(self):
+        instruction = Instruction(0, 2, "call", "eax", "ffd0")
+        instruction.operands = [Operand(type="reg", reg="eax")]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("uint32_t _icall_target = eax", lifted[0])
+        self.assertIn(
+            "RECOMP_ICALL_SAFE(_icall_target, _icall_esp)", lifted[0])
+
+    def test_esp_relative_indirect_call_snapshots_target_before_push(self):
+        instruction = Instruction(0, 4, "call", "dword ptr [esp + 0xc]", "ff54240c")
+        instruction.operands = [Operand(
+            type="mem", mem_base="esp", mem_disp=0xc, mem_size=4)]
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("uint32_t _icall_target = MEM32(esp + 0xC)", lifted[0])
+        self.assertLess(
+            lifted[0].index("uint32_t _icall_target"),
+            lifted[0].index("PUSH32(esp, 0)"))
+        self.assertIn(
+            "RECOMP_ICALL_SAFE(_icall_target, _icall_esp)", lifted[0])
+
+    def test_call_without_local_ebp_keeps_existing_bridge(self):
+        instruction = Instruction(0, 5, "call", "0x123456", "e800000000")
+        instruction.call_target = 0x00123456
+
+        lifted = Lifter().lift_instruction(instruction)
+
+        self.assertEqual(len(lifted), 1)
+        self.assertIn("sub_00123456();", lifted[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_sse.py
+++ b/tools/recomp/test_lifter_sse.py
@@ -1,0 +1,175 @@
+import unittest
+
+from .disasm import Instruction, Operand
+from .lifter import Lifter
+
+
+def _insn(mnemonic, op_str, operands):
+    instruction = Instruction(0, 4, mnemonic, op_str, "")
+    instruction.operands = operands
+    return instruction
+
+
+def _xmm(name):
+    return Operand(type="reg", reg=name)
+
+
+def _mem(base=None, disp=0, size=16):
+    return Operand(type="mem", mem_base=base, mem_disp=disp, mem_size=size)
+
+
+class SsePackedLifterTest(unittest.TestCase):
+    """An XMM register is 128 bits wide. Lifting packed moves as scalar
+    floats transferred 4 of every 16 bytes, which left every matrix built by
+    packed SSE sparse, and dropped packed arithmetic to a bare comment."""
+
+    def test_aligned_packed_load_transfers_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movaps", "xmm0, xmmword ptr [eax]",
+                      [_xmm("xmm0"), _mem("eax")])),
+            ["xmm0 = XMM_MEM(eax); /* movaps */"],
+        )
+
+    def test_aligned_packed_store_transfers_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movaps", "xmmword ptr [ecx], xmm0",
+                      [_mem("ecx"), _xmm("xmm0")])),
+            ["XMM_STORE(ecx, xmm0); /* movaps */"],
+        )
+
+    def test_unaligned_packed_move_is_also_sixteen_bytes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movups", "xmmword ptr [ecx + 0x10], xmm1",
+                      [_mem("ecx", 0x10), _xmm("xmm1")])),
+            ["XMM_STORE(ecx + 0x10, xmm1); /* movups */"],
+        )
+
+    def test_scalar_move_stays_on_lane_zero(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movss", "xmm0, dword ptr [eax + 4]",
+                      [_xmm("xmm0"), _mem("eax", 4, size=4)])),
+            ["xmm0 = XMM_SCALAR(MEMF(eax + 4)); /* movss */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movss", "dword ptr [ecx], xmm2",
+                      [_mem("ecx", 0, size=4), _xmm("xmm2")])),
+            ["MEMF(ecx) = xmm2.f[0]; /* movss */"],
+        )
+
+    def test_packed_arithmetic_emits_a_statement(self):
+        for mnemonic, helper in (("mulps", "XMM_MUL"), ("addps", "XMM_ADD"),
+                                 ("subps", "XMM_SUB"), ("divps", "XMM_DIV")):
+            self.assertEqual(
+                Lifter().lift_instruction(
+                    _insn(mnemonic, "xmm0, xmm1",
+                          [_xmm("xmm0"), _xmm("xmm1")])),
+                ["xmm0 = %s(xmm0, xmm1); /* %s */" % (helper, mnemonic)],
+            )
+
+    def test_packed_arithmetic_against_memory(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("mulps", "xmm0, xmmword ptr [0xa24190]",
+                      [_xmm("xmm0"), _mem(disp=0xA24190)])),
+            ["xmm0 = XMM_MUL(xmm0, XMM_MEM(0xA24190)); /* mulps */"],
+        )
+
+    def test_shuffle_uses_the_immediate(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("shufps", "xmm7, xmm7, 0",
+                      [_xmm("xmm7"), _xmm("xmm7"),
+                       Operand(type="imm", imm=0)])),
+            ["xmm7 = XMM_SHUFFLE(xmm7, xmm7, 0); /* shufps */"],
+        )
+
+    def test_bitwise_ops_use_the_integer_lanes(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("andps", "xmm4, xmmword ptr [0x240430]",
+                      [_xmm("xmm4"), _mem(disp=0x240430)])),
+            ["xmm4 = XMM_AND(xmm4, XMM_MEM(0x240430)); /* andps */"],
+        )
+
+    def test_self_xor_zeroes_the_whole_register(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("xorps", "xmm0, xmm0",
+                      [_xmm("xmm0"), _xmm("xmm0")])),
+            ["xmm0 = XMM_ZERO(); /* xorps self = zero */"],
+        )
+
+    def test_move_mask_gathers_real_sign_bits(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movmskps", "eax, xmm3",
+                      [Operand(type="reg", reg="eax"), _xmm("xmm3")])),
+            ["eax = XMM_MOVEMASK(xmm3); /* movmskps */"],
+        )
+
+    def test_half_width_moves_target_one_half(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movlps", "xmm0, qword ptr [ecx]",
+                      [_xmm("xmm0"), _mem("ecx", 0, size=8)])),
+            ["XMM_LOAD_LOW(xmm0, ecx); /* movlps */"],
+        )
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("movhps", "qword ptr [eax + 8], xmm1",
+                      [_mem("eax", 8, size=8), _xmm("xmm1")])),
+            ["XMM_STORE_HIGH(eax + 8, xmm1); /* movhps */"],
+        )
+
+    def test_scalar_arithmetic_reads_and_writes_lane_zero(self):
+        self.assertEqual(
+            Lifter().lift_instruction(
+                _insn("mulss", "xmm0, xmm1",
+                      [_xmm("xmm0"), _xmm("xmm1")])),
+            ["xmm0.f[0] = xmm0.f[0] * xmm1.f[0]; /* mulss */"],
+        )
+
+    def test_no_packed_mnemonic_falls_through_to_a_bare_comment(self):
+        packed = [
+            ("movaps", [_xmm("xmm0"), _mem("eax")]),
+            ("movups", [_xmm("xmm0"), _mem("eax")]),
+            ("movlps", [_xmm("xmm0"), _mem("eax", 0, size=8)]),
+            ("movhps", [_xmm("xmm0"), _mem("eax", 0, size=8)]),
+            ("movlhps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("movhlps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("addps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("subps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("mulps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("divps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("minps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("maxps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("andps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("andnps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("orps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("xorps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("unpcklps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("unpckhps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpeqps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpneqps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpltps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("cmpleps", [_xmm("xmm0"), _xmm("xmm1")]),
+            ("shufps", [_xmm("xmm0"), _xmm("xmm1"),
+                        Operand(type="imm", imm=0x55)]),
+            ("movmskps", [Operand(type="reg", reg="eax"), _xmm("xmm0")]),
+        ]
+        for mnemonic, operands in packed:
+            lifted = Lifter().lift_instruction(_insn(mnemonic, "", operands))
+            self.assertEqual(len(lifted), 1, mnemonic)
+            statement = lifted[0]
+            self.assertIn(";", statement, (mnemonic, statement))
+            self.assertFalse(
+                statement.lstrip().startswith("/*"), (mnemonic, statement))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_lifter_string_compare.py
+++ b/tools/recomp/test_lifter_string_compare.py
@@ -1,0 +1,70 @@
+import unittest
+
+from .disasm import BasicBlock, Instruction, Operand
+from .lifter import Lifter, lift_basic_block
+
+
+class StringCompareLifterTest(unittest.TestCase):
+    def test_repne_scasb_scans_until_equal(self):
+        scan = Instruction(
+            0, 2, "repne scasb", "al, byte ptr es:[edi]", "f2ae")
+
+        lifted = Lifter().lift_instruction(scan)
+        generated = "\n".join(lifted)
+
+        self.assertIn("while (ecx != 0)", generated)
+        self.assertIn("_flags = (LO8(eax) == MEM8(edi));", generated)
+        self.assertIn("edi++; ecx--;", generated)
+        self.assertIn("if (_flags) break;", generated)
+        self.assertLess(
+            generated.index("edi++; ecx--;"),
+            generated.index("if (_flags) break;"),
+        )
+
+    def test_repe_cmpsb_compares_bytes_and_feeds_equal_jump(self):
+        compare = Instruction(
+            0, 2, "repe cmpsb", "byte ptr [esi], byte ptr es:[edi]",
+            "f3a6")
+        compare.operands = [
+            Operand(type="mem", mem_base="esi", mem_size=1),
+            Operand(type="mem", mem_base="edi", mem_size=1),
+        ]
+        jump = Instruction(2, 2, "je", "0x10", "740c")
+        jump.jump_target = 0x10
+        lifter = Lifter()
+        lifter.func_start = 0
+        lifter.func_end = 0x20
+
+        lifted, _ = lift_basic_block(
+            lifter, BasicBlock(start=0, instructions=[compare, jump]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("_flags = (MEM8(esi) == MEM8(edi));", generated)
+        self.assertIn("esi++; edi++; ecx--;", generated)
+        self.assertIn("if (!_flags) break;", generated)
+        self.assertIn("if ((_flags != 0)) goto loc_00000010;", generated)
+
+    def test_unsupported_dword_compare_does_not_claim_byte_flags(self):
+        compare = Instruction(
+            0, 2, "repe cmpsd", "dword ptr [esi], dword ptr es:[edi]",
+            "f3a7")
+        compare.operands = [
+            Operand(type="mem", mem_base="esi", mem_size=4),
+            Operand(type="mem", mem_base="edi", mem_size=4),
+        ]
+        jump = Instruction(2, 2, "je", "0x10", "740c")
+        jump.jump_target = 0x10
+        lifter = Lifter()
+        lifter.func_start = 0
+        lifter.func_end = 0x20
+
+        lifted, _ = lift_basic_block(
+            lifter, BasicBlock(start=0, instructions=[compare, jump]))
+        generated = "\n".join(lifted)
+
+        self.assertIn("repe cmpsd - string compare", generated)
+        self.assertNotIn("(_flags != 0)", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_runtime_helpers_defined.py
+++ b/tools/recomp/test_runtime_helpers_defined.py
@@ -1,0 +1,67 @@
+"""Every helper the lifter emits must exist in the runtime header.
+
+The lifter names helpers as strings, so nothing ties them to the runtime
+that has to define them. A helper can be added to a lift rule and simply
+never defined: the Python tests keep passing -- they only compare emitted
+text -- and the failure surfaces much later as a compile error in the
+generated C, on whichever title first happens to use that instruction.
+
+This walks the helper names out of the lifter source and checks the header
+actually defines each one.
+"""
+
+import pathlib
+import re
+import unittest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_LIFTER = _ROOT / "tools" / "recomp" / "lifter.py"
+_RUNTIME = _ROOT / "templates" / "runtime" / "recomp_types.h"
+
+# XMM_LOAD_/XMM_STORE_ are f-string prefixes completed with LOW/HIGH.
+_PREFIXES = {"XMM_LOAD_": ("LOW", "HIGH"), "XMM_STORE_": ("LOW", "HIGH")}
+
+
+def _emitted_helpers():
+    src = _LIFTER.read_text(encoding="utf-8")
+    names = set()
+    for raw in re.findall(r"\bXMM_[A-Z0-9_]*", src):
+        if raw in _PREFIXES:
+            names.update(raw + half for half in _PREFIXES[raw])
+        else:
+            names.add(raw)
+    return names
+
+
+def _defined_helpers():
+    src = _RUNTIME.read_text(encoding="utf-8")
+    defined = set(re.findall(r"^\s*#define\s+(XMM_[A-Z0-9_]+)", src, re.M))
+    # static inline functions count as definitions too
+    defined.update(re.findall(r"\b(XMM_[A-Z0-9_]+)\s*\([^)]*\)\s*\{", src))
+    # ...including the ones built by the lane-wise/bitwise generator macros
+    defined.update(re.findall(r"^RECOMP_XMM_\w+\((XMM_[A-Z0-9_]+),", src, re.M))
+    return defined
+
+
+class RuntimeHelpersDefinedTest(unittest.TestCase):
+    def test_every_emitted_xmm_helper_is_defined(self):
+        missing = sorted(_emitted_helpers() - _defined_helpers())
+        self.assertEqual(
+            missing, [],
+            "lifter emits XMM helpers the runtime header never defines; the "
+            "generated C would not compile: " + ", ".join(missing))
+
+    def test_xmm_registers_are_global_state(self):
+        """PR #10 removed the function-local declaration, so the runtime has
+        to supply the storage and map the guest names onto it."""
+        runtime = _RUNTIME.read_text(encoding="utf-8")
+        for i in range(8):
+            self.assertIn(f"#define xmm{i} g_xmm{i}", runtime)
+        self.assertIn("typedef union RecompXmm", runtime)
+        main_c = (_ROOT / "templates" / "new-game" / "src" / "main.c").read_text(
+            encoding="utf-8")
+        self.assertIn("RecompXmm g_xmm0", main_c)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/test_translator_xmm_state.py
+++ b/tools/recomp/test_translator_xmm_state.py
@@ -1,0 +1,42 @@
+import unittest
+
+from .disasm import Instruction, Operand
+from .translator import FunctionTranslator
+
+
+def _insn(mnemonic, op_str, operands):
+    instruction = Instruction(0, 4, mnemonic, op_str, "")
+    instruction.operands = operands
+    return instruction
+
+
+class XmmIsGlobalStateTest(unittest.TestCase):
+    """XMM is architectural state, like the GPRs and the x87 stack.
+
+    The lifter splits one guest routine into several C functions, so a value
+    produced in one block and read in the next is lost if XMM lives on the C
+    stack. A function-local declaration also shadows the runtime's global
+    register file, which is worse than merely losing the value: the local
+    starts zeroed, so a returned float silently reads as 0.0 instead of
+    keeping whatever the previous block computed.
+    """
+
+    def _declarations(self, instructions):
+        translator = FunctionTranslator.__new__(FunctionTranslator)
+        used = translator._find_used_xmm(instructions)
+        self.assertTrue(used, "expected the scan to see an XMM register")
+        return used
+
+    def test_scan_still_reports_xmm_use(self):
+        used = self._declarations([
+            _insn("movaps", "xmm0, xmmword ptr [eax]",
+                  [Operand(type="reg", reg="xmm0"),
+                   Operand(type="mem", mem_base="eax", mem_disp=0,
+                           mem_size=16)]),
+        ])
+
+        self.assertIn("xmm0", used)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -312,15 +312,17 @@ class FunctionTranslator:
             if mmx_regs:
                 lines.append(f"    uint64_t {', '.join(mmx_regs)};")
 
-        # FPU stack (simplified)
+        # The x87 stack is architectural state and survives guest calls. Some
+        # detector boundaries also split one original CRT helper into several
+        # generated C functions, so function-local storage loses live ST values.
         if has_fpu:
-            lines.append(f"    double _fp_stack[8];")
-            lines.append(f"    int _fp_top = 0;")
-            lines.append(f"    #define fp_push(v) (_fp_stack[--_fp_top & 7] = (v))")
-            lines.append(f"    #define fp_pop() (_fp_top++)")
-            lines.append(f"    #define fp_popp() (fp_pop())")
-            lines.append(f"    #define fp_top() _fp_stack[_fp_top & 7]")
-            lines.append(f"    #define fp_st1() _fp_stack[(_fp_top + 1) & 7]")
+            lines.append(f"    #define fp_push(v) do {{ double _fp_value = (v); \\")
+            lines.append(f"        g_fp_top = (g_fp_top + 7u) & 7u; \\")
+            lines.append(f"        g_fp_stack[g_fp_top] = _fp_value; }} while (0)")
+            lines.append(f"    #define fp_pop() (g_fp_top = (g_fp_top + 1u) & 7u)")
+            lines.append(f"    #define fp_top() g_fp_stack[g_fp_top]")
+            lines.append(f"    #define fp_st(i) g_fp_stack[(g_fp_top + (i)) & 7u]")
+            lines.append(f"    #define fp_st1() fp_st(1)")
 
         # For fpo_leaf functions that use ebp: initialize from g_seh_ebp.
         # In x86, these functions inherit EBP from their caller (typically
@@ -418,8 +420,8 @@ class FunctionTranslator:
         if has_fpu:
             lines.append(f"    #undef fp_push")
             lines.append(f"    #undef fp_pop")
-            lines.append(f"    #undef fp_popp")
             lines.append(f"    #undef fp_top")
+            lines.append(f"    #undef fp_st")
             lines.append(f"    #undef fp_st1")
 
         lines.append(f"}}")

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -489,16 +489,35 @@ class FunctionTranslator:
         if any(insn.mnemonic == "leave" for insn in instructions):
             used_regs.add("ebp")
 
+        # Guest control leaves the bottom of this function when its last
+        # instruction neither returns, jumps, nor traps. A function the lifter
+        # split into consecutive pieces continues into the next piece exactly
+        # as an unconditional tail jump would, so bridge to it the same way.
+        # Only an address that is itself a translated function start is a
+        # usable target; anything else is an analysis boundary gap with no
+        # callable symbol.
+        last_insn = instructions[-1]
+        continues_past_end = not (
+            last_insn.is_terminator
+            or last_insn.mnemonic in ("int3", "ud2", "hlt"))
+        fallthrough_target = None
+        if (continues_past_end and end in self.func_db
+                and end not in self.owned_function_starts):
+            fallthrough_target = end
+
         # Ensure ebp tracked if function has tail jumps (lifter emits
-        # g_seh_ebp = ebp before external jmp and indirect jmp).
+        # g_seh_ebp = ebp before external jmp, external jcc, and indirect jmp,
+        # and translate_function emits it before a fallthrough tail call).
         has_tail_jump = any(
-            insn.mnemonic == "jmp" and (
+            (insn.mnemonic == "jmp" and (
                 (insn.jump_target and not (start <= insn.jump_target < end))
                 or not insn.jump_target  # indirect jmp
-            )
+            ))
+            or (insn.is_cond_jump and insn.jump_target
+                and not (start <= insn.jump_target < end))
             for insn in instructions
         )
-        if has_tail_jump:
+        if has_tail_jump or fallthrough_target is not None:
             used_regs.add("ebp")
 
         # Ensure ebp tracked if function calls __SEH_prolog or __SEH_epilog
@@ -642,6 +661,13 @@ class FunctionTranslator:
             for stmt in stmts:
                 lines.append(f"    {stmt}")
 
+            lines.append(f"")
+
+        # Continue into the next function when control runs off the bottom.
+        if fallthrough_target is not None:
+            ft_name = self.lifter._call_target_name(fallthrough_target)
+            lines.append(f"    g_seh_ebp = ebp; {ft_name}(); return;"
+                         f" /* fallthrough 0x{fallthrough_target:08X} */")
             lines.append(f"")
 
         # Insert _icall_esp save points before RECOMP_ICALL_SAFE arg pushes.

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -293,15 +293,6 @@ class FunctionTranslator:
         if has_carry:
             lines.append(f"    int _cf = 0; /* carry flag */")
 
-        # Add _fpu_cmp for FPU compare instructions (both old and new style)
-        has_fpu_cmp = any(insn.mnemonic in ("fcompi", "fcomip", "fucomi",
-                                             "fucompi", "fucomip", "fcomi",
-                                             "fcom", "fcomp", "fcompp",
-                                             "fucom", "fucomp", "fucompp")
-                          for insn in instructions)
-        if has_fpu_cmp:
-            lines.append(f"    int _fpu_cmp = 0; /* FPU compare result: -1/0/1 */")
-
         # SSE/MMX register declarations
         if used_xmm:
             xmm_regs = sorted([r for r in used_xmm if r.startswith("xmm")])

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -307,8 +307,11 @@ class FunctionTranslator:
             xmm_regs = sorted([r for r in used_xmm if r.startswith("xmm")])
             mmx_regs = sorted([r for r in used_xmm if r.startswith("mm")
                                and not r.startswith("xmm")])
-            if xmm_regs:
-                lines.append(f"    float {', '.join(xmm_regs)};")
+            # XMM is architectural state and is declared globally by the
+            # runtime, exactly like the GPRs and the x87 stack. Declaring it
+            # here would shadow that global with a fresh zeroed local, so a
+            # value produced in one block and read in the next - a return
+            # value in xmm0, or a spill straddling a branch - would be lost.
             if mmx_regs:
                 lines.append(f"    uint64_t {', '.join(mmx_regs)};")
 

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -11,8 +11,10 @@ For each function:
 Produces compilable C code using recomp_types.h macros.
 """
 
+import bisect
 import json
 import os
+import struct
 
 # Import the functions, not the VA constants: configure_from_xbe() rebinds those
 # at startup, so a by-value import would freeze the fallback layout.
@@ -114,6 +116,150 @@ class FunctionTranslator:
         self.lifter = Lifter(func_db=func_db, label_db=label_db, abi_db=abi_db,
                              xbe_data=xbe_data, seh_prolog=seh_prolog,
                              seh_epilog=seh_epilog)
+        self.owned_function_starts = set()
+        self._recovered_cfg = {}
+        self._ownership_ready = False
+
+    @staticmethod
+    def _is_strong_entry(func_info):
+        """Return whether an entry has evidence independent of seed recovery."""
+        return bool(func_info.get("has_prologue") or func_info.get("called_by"))
+
+    def discover_cfg_ownership(self):
+        """Reassign weak seeds reached through a split computed-jump CFG."""
+        if self._ownership_ready:
+            return
+        self._ownership_ready = True
+
+        by_section = {}
+        weak_by_section = {}
+        for addr, info in self.func_db.items():
+            section = info.get("section", "")
+            if self._is_strong_entry(info):
+                by_section.setdefault(section, []).append(addr)
+            else:
+                weak_by_section.setdefault(section, []).append(addr)
+
+        for section, strong_starts in by_section.items():
+            strong_starts.sort()
+            weak_starts = sorted(weak_by_section.get(section, []))
+            for index, start in enumerate(strong_starts[:-1]):
+                original_end = self.func_db[start].get("end", start)
+                upper = strong_starts[index + 1]
+                if original_end >= upper:
+                    continue
+
+                weak_index = bisect.bisect_left(weak_starts, original_end)
+                if (weak_index >= len(weak_starts)
+                        or weak_starts[weak_index] >= upper):
+                    continue
+
+                raw_prefix = self._read_func_bytes(start, original_end)
+                if not raw_prefix:
+                    continue
+                prefix = self.disasm.disassemble_function(
+                    raw_prefix, start, original_end)
+                bridges = {
+                    insn.jump_target
+                    for insn in prefix
+                    if (insn.is_cond_jump and insn.jump_target is not None
+                        and original_end <= insn.jump_target < upper)
+                }
+                has_indexed_jump = any(
+                    insn.is_jump and insn.jump_target is None
+                    and insn.operands and insn.operands[0].type == "mem"
+                    and insn.operands[0].mem_index
+                    for insn in prefix)
+                if not bridges or not has_indexed_jump:
+                    continue
+
+                stop_addresses = {
+                    addr for addr in self.func_db if start < addr < upper
+                }
+                recovered = self._recover_cfg(
+                    start, upper, bridges, stop_addresses)
+                if recovered is None:
+                    continue
+                instructions, jump_tables, cfg_targets = recovered
+                owned = {
+                    addr for addr in weak_starts[weak_index:]
+                    if addr < upper and addr in cfg_targets
+                }
+                if not owned:
+                    continue
+
+                self.owned_function_starts.update(owned)
+                self._recovered_cfg[start] = {
+                    "end": max(insn.end_address for insn in instructions),
+                    "instructions": instructions,
+                    "jump_tables": jump_tables,
+                }
+
+    def _recover_cfg(self, start, upper, bridge_targets, stop_addresses):
+        """Decode direct CFG edges and local indexed-table destinations."""
+        raw_bytes = self._read_func_bytes(start, upper)
+        if not raw_bytes:
+            return None
+
+        entry_points = {start, *bridge_targets}
+        jump_tables = {}
+        while True:
+            instructions = self.disasm.disassemble_cfg(
+                raw_bytes, start, upper, entry_points,
+                stop_addresses=stop_addresses)
+            changed = False
+            for insn in instructions:
+                if not insn.is_jump or insn.jump_target is not None:
+                    continue
+                if not insn.operands or insn.operands[0].type != "mem":
+                    continue
+                operand = insn.operands[0]
+                if not operand.mem_index or operand.mem_base:
+                    continue
+                table_va = operand.mem_disp
+                if not (start <= table_va < upper):
+                    continue
+                targets = self._read_local_jump_table(table_va, start, upper)
+                if not targets:
+                    continue
+                jump_tables[table_va] = targets
+                for target in targets:
+                    if target not in entry_points:
+                        entry_points.add(target)
+                        changed = True
+            if not changed:
+                cfg_targets = {
+                    insn.jump_target
+                    for insn in instructions
+                    if insn.jump_target is not None
+                    and start <= insn.jump_target < upper
+                }
+                for targets in jump_tables.values():
+                    cfg_targets.update(targets)
+                return instructions, jump_tables, cfg_targets
+
+    def _read_local_jump_table(self, table_va, lower, upper,
+                               max_entries=256):
+        """Read the contiguous pointer cluster around an indexed-jump base."""
+        def scan(step, first):
+            targets = []
+            for index in range(first, max_entries + first):
+                entry_va = table_va + step * index * 4
+                offset = va_to_file_offset(entry_va)
+                if offset is None or offset + 4 > len(self.xbe_data):
+                    break
+                target = struct.unpack_from('<I', self.xbe_data, offset)[0]
+                if not (lower <= target < upper):
+                    break
+                targets.append(target)
+            return targets
+
+        backward = scan(-1, 1)
+        forward = scan(1, 0)
+        if len(backward) + len(forward) < 2:
+            return []
+        backward.reverse()
+        return backward + forward
 
     def _read_func_bytes(self, start_va, end_va):
         """Read raw bytes for a function from the XBE."""
@@ -148,7 +294,8 @@ class FunctionTranslator:
         Returns a string of C source code, or None on failure.
         """
         start = func_addr
-        end = func_info.get("end")
+        recovered = self._recovered_cfg.get(start)
+        end = recovered["end"] if recovered else func_info.get("end")
         if not end:
             end = start + func_info.get("size", 0)
         if end <= start:
@@ -165,9 +312,12 @@ class FunctionTranslator:
         # Set function bounds for the lifter
         self.lifter.func_start = start
         self.lifter.func_end = end
+        self.lifter.jump_table_targets = (
+            recovered["jump_tables"] if recovered else {})
 
         # Disassemble
-        instructions = self.disasm.disassemble_function(raw_bytes, start, end)
+        instructions = (recovered["instructions"] if recovered else
+                        self.disasm.disassemble_function(raw_bytes, start, end))
         if not instructions:
             return None
 
@@ -530,6 +680,7 @@ class BatchTranslator:
             self.xbe_data, self.func_db, self.label_db,
             self.classification_db, self.abi_db,
             seh_prolog=seh_prolog, seh_epilog=seh_epilog)
+        self.translator.discover_cfg_ownership()
 
     def get_functions_by_category(self, categories=None, exclude_categories=None):
         """
@@ -538,6 +689,8 @@ class BatchTranslator:
         """
         result = []
         for addr, func_info in sorted(self.func_db.items()):
+            if addr in self.translator.owned_function_starts:
+                continue
             cls_info = self.classification_db.get(addr, {})
             cat = cls_info.get("category", "unknown")
 
@@ -575,6 +728,9 @@ class BatchTranslator:
         Returns dict with statistics.
         """
         os.makedirs(self.output_dir, exist_ok=True)
+
+        func_list = [item for item in func_list
+                     if item[0] not in self.translator.owned_function_starts]
 
         if max_funcs:
             func_list = func_list[:max_funcs]
@@ -688,6 +844,9 @@ class BatchTranslator:
         import sys
 
         os.makedirs(output_dir, exist_ok=True)
+
+        func_list = [item for item in func_list
+                     if item[0] not in self.translator.owned_function_starts]
 
         # Translate all functions first, collecting results
         translations = []

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -117,8 +117,131 @@ class FunctionTranslator:
                              xbe_data=xbe_data, seh_prolog=seh_prolog,
                              seh_epilog=seh_epilog)
         self.owned_function_starts = set()
+        self.recovered_function_starts = set()
         self._recovered_cfg = {}
         self._ownership_ready = False
+
+    def discover_static_indirect_targets(self):
+        """Recover function entries from bounded static callback tables."""
+        original_starts = sorted(self.func_db)
+        recovered_callers = {}
+
+        for caller, func_info in list(self.func_db.items()):
+            end = func_info.get("end", caller)
+            raw_bytes = self._read_func_bytes(caller, end)
+            if not raw_bytes:
+                continue
+            instructions = self.disasm.disassemble_function(
+                raw_bytes, caller, end)
+            for lower, upper in self._find_static_indirect_ranges(instructions):
+                targets = self._read_static_callback_table(
+                    lower, upper, original_starts)
+                if targets is None:
+                    continue
+                for target in targets:
+                    if target not in self.func_db:
+                        recovered_callers.setdefault(target, set()).add(caller)
+
+        for target, callers in sorted(recovered_callers.items()):
+            next_index = bisect.bisect_right(original_starts, target)
+            if next_index == 0 or next_index >= len(original_starts):
+                continue
+            previous = self.func_db[original_starts[next_index - 1]]
+            next_start = original_starts[next_index]
+            next_func = self.func_db[next_start]
+            if previous.get("end", previous["_addr"]) > target:
+                continue
+            section = next_func.get("section", "")
+            if section in (".rdata", ".data"):
+                continue
+
+            raw_bytes = self._read_func_bytes(target, next_start)
+            if not raw_bytes:
+                continue
+            instructions = self.disasm.disassemble_function(
+                raw_bytes, target, next_start)
+            if not instructions or not any(insn.is_ret for insn in instructions):
+                continue
+
+            self.func_db[target] = {
+                "_addr": target,
+                "start": f"0x{target:08X}",
+                "end": next_start,
+                "size": next_start - target,
+                "name": self.label_db.get(target, f"sub_{target:08X}"),
+                "section": section,
+                "confidence": 0.9,
+                "detection_method": "static_indirect_table",
+                "num_instructions": len(instructions),
+                "has_prologue": self._func_has_prologue(instructions),
+                "calls_to": [],
+                "called_by": sorted(callers),
+            }
+            self.recovered_function_starts.add(target)
+
+        return self.recovered_function_starts
+
+    @staticmethod
+    def _find_static_indirect_ranges(instructions, max_bytes=0x10000):
+        """Find immediate-backed ranges in functions that call a register."""
+        constants = {}
+        ranges = set()
+        has_indirect_call = False
+
+        for insn in instructions:
+            operands = insn.operands
+            if (insn.mnemonic == "mov" and len(operands) >= 2
+                    and operands[0].type == "reg"):
+                destination = operands[0].reg
+                source = operands[1]
+                if source.type == "imm":
+                    constants[destination] = source.imm
+                elif source.type == "reg" and source.reg in constants:
+                    constants[destination] = constants[source.reg]
+                else:
+                    constants.pop(destination, None)
+            elif (insn.mnemonic == "cmp" and len(operands) >= 2
+                    and operands[0].type == "reg"
+                    and operands[1].type == "reg"):
+                lower = constants.get(operands[0].reg)
+                upper = constants.get(operands[1].reg)
+                if (lower is not None and upper is not None
+                        and lower < upper and lower % 4 == 0
+                        and upper % 4 == 0 and upper - lower <= max_bytes):
+                    ranges.add((lower, upper))
+            elif (insn.is_call and insn.call_target is None
+                    and operands and operands[0].type == "reg"):
+                has_indirect_call = True
+
+        return sorted(ranges) if has_indirect_call else []
+
+    def _read_static_callback_table(self, lower, upper, original_starts):
+        """Validate and return a bounded table of static code pointers."""
+        targets = []
+        for entry_va in range(lower, upper, 4):
+            offset = va_to_file_offset(entry_va)
+            if offset is None or offset + 4 > len(self.xbe_data):
+                return None
+            target = struct.unpack_from('<I', self.xbe_data, offset)[0]
+            if target in (0, 0xFFFFFFFF):
+                continue
+
+            index = bisect.bisect_right(original_starts, target)
+            if index and self.func_db[original_starts[index - 1]].get(
+                    "end", original_starts[index - 1]) > target:
+                targets.append(target)
+                continue
+            if index == 0 or index >= len(original_starts):
+                return None
+            previous = self.func_db[original_starts[index - 1]]
+            following = self.func_db[original_starts[index]]
+            if (previous.get("section") != following.get("section")
+                    or following.get("section") in (".rdata", ".data")
+                    or va_to_file_offset(target) is None):
+                return None
+            targets.append(target)
+
+        return targets if targets else None
 
     @staticmethod
     def _is_strong_entry(func_info):
@@ -680,6 +803,7 @@ class BatchTranslator:
             self.xbe_data, self.func_db, self.label_db,
             self.classification_db, self.abi_db,
             seh_prolog=seh_prolog, seh_epilog=seh_epilog)
+        self.translator.discover_static_indirect_targets()
         self.translator.discover_cfg_ownership()
 
     def get_functions_by_category(self, categories=None, exclude_categories=None):

--- a/tools/symbols/test_map_names.py
+++ b/tools/symbols/test_map_names.py
@@ -6,7 +6,14 @@ import json
 import tempfile
 from pathlib import Path
 
-from map_names import check_entry, parse_map, port_names, va_to_off
+# tools.symbols is a package, so pytest imports this as a package member
+# and a bare `import map_names` fails at collection. The docstring above
+# also invites running it directly, where there is no parent package --
+# so try the package-relative import first and fall back to the flat one.
+try:
+    from .map_names import check_entry, parse_map, port_names, va_to_off
+except ImportError:  # executed as a script
+    from map_names import check_entry, parse_map, port_names, va_to_off
 
 # A title with .text at 0x11000 and an XDK section at 0x50000, mirroring the
 # real layout: MAP section 0001 -> XBE section 0.


### PR DESCRIPTION
Folds in every open community PR, gives the people behind them a proper record, and closes the licensing gap the repository's own `LICENSES/README.md` flagged.

Authorship is preserved through merge commits, so **@DarthSidious666** and **@NoRain211** appear in the GitHub contributors sidebar once this lands on `main`.

## What's merged

| PR | Author | State |
|---|---|---|
| #6 — `tools/abi_analysis` | @DarthSidious666 | clean |
| #7 — CFG / call recovery | @NoRain211 | clean |
| #8 — flags, carry, compare width | @NoRain211 | clean |
| #9 — packed SSE + x87 | @NoRain211 | needed the runtime half |
| #10 — XMM as guest state | @NoRain211 | needed the runtime half |

`pytest tools/`: **67 passed** (on `main` it was a collection error and 0 tests run — see below).

## #9 and #10 needed a runtime that wasn't in the diffs

The lifter work in both PRs is right, and the model behind #10 is right: XMM is architectural state, not a function local. But the runtime half never arrived, and neither PR's tests catch it — they compare *emitted text* and never compile it.

The lifter emits **28 distinct `XMM_*` helpers** (`XMM_ADD`, `XMM_MEM`, `XMM_SHUFFLE`, `XMM_ZERO`, …) and `recomp_types.h` defined **none** of them, nor the union they operate on. #10 then removed the local `float xmm0;` declaration, which is the correct change but left the names undeclared as well. The first `movaps` in any title would have failed the build.

Verified by lifting real SSE bytes and diffing emitted helpers against the header: 28 emitted, 0 defined.

So `f34c2b4` supplies it:

- `RecompXmm` — 16-byte union with per-lane views (`f`/`d`/`u`/`i`/`q`).
- Storage as globals beside the volatile GPRs, with `xmmN` → `g_xmmN` under `RECOMP_GENERATED_CODE`, exactly as `eax` → `g_eax` already works.
- All 28 helpers as lane-wise `static inline`s.

Lane-wise C rather than host intrinsics, because that's where the guest semantics differ from the obvious C and the difference should be visible:

- `MINPS`/`MAXPS` return the **second** operand on a tie or unordered compare — that's the hardware tie-break, not `fmin`/`fmax`.
- `ANDNPS` is `~dst & src`, not `dst & ~src`.
- `CMPNEQPS` is the **unordered** form, so it's true when a lane is NaN, while EQ/LT/LE are ordered and false there.
- Loads/stores go lane-wise through `MEM32`, so `movups` stays unaligned-safe and every access still passes through `XBOX_PTR`.

**Verified by compiling, not just by asserting on strings:** 31 lifted SSE instructions covering all 28 helpers build clean under MSVC `/W3`, and a semantic harness checks `shufps`/`unpck*` lane order, `movmskps`, `andnps`, and the min/max tie-break against the documented hardware behaviour.

`test_runtime_helpers_defined.py` closes the gap permanently: it walks helper names out of `lifter.py` and asserts the header defines each one. Nothing else tied those two files together. Mutation-tested — deleting `XMM_ADD` from the header makes it fail.

## The test suite wasn't running at all

`tools/symbols/test_map_names.py` did a bare `import map_names` from inside a package, which aborted pytest collection for the **entire** `tools/` tree — so `pytest tools/` on `main` reported one error and ran none of the other tests. Relative import with a fallback for the documented script-mode invocation; both work. That's how the suite goes from 0 to 67.

`CONTRIBUTING.md` also claimed there's no automated test suite. It now says how to run it.

## Licensing

`LICENSE` is **byte-identical** to `main` — deliberately. It's clean MIT, which is what lets GitHub detect and display the licence, and prepending an LGPL preamble would risk that.

The real gap is that the repo ships the MCPX APU sources and `src/nv2a/nv2a_regs.h`, extracted from xemu and LGPL-2.1-or-later, with per-file copyright headers intact but **no top-level NOTICE and no copy of the licence**. Shipping the verbatim text alongside LGPL'd files is a requirement, not a courtesy — `LICENSES/README.md` said so itself and then didn't ship it.

- `LICENSES/LGPL-2.1.txt` — verbatim, from gnu.org.
- `NOTICE` — every affected file with the copyright it actually carries, checked file by file rather than assumed. Worth noting: `apu_shim.h` is this project's own file released under LGPL because it only exists to host the extracted code, and several files under `src/apu/`/`src/nv2a/` are **not** xemu-derived and aren't listed.

## Credits

The README's "Credits" section credited Claude Code and not one human being.

`CONTRIBUTORS.md` is now the canonical record, in the same shape as ps3recomp's — what each person actually found, in enough detail to be worth reading.

It deliberately includes the two issue reporters:

- **@Tiptup300** (#1) found that every documented getting-started step was broken, on Linux, which is not a platform any of it had been tried on. That report is the origin of `21488f4` — and of this repository having a LICENSE file at all, which the README had claimed for months without one existing.
- **@M0RSM4LLEO** (#2) reproduced it with exact commands, tracebacks and versions, spotted that `tools/xbe_parser` was the only tool package with no `__main__.py`, and kept testing through each fix — which is how the `write_summary` crash at the very end of a full run got found.

A good bug report is a contribution, and the file says so.

## Notes / follow-ups

- Issue #2's three parts are now all resolved: `__main__.py` and the `write_summary` crash were already fixed on `main`; the missing `abi_analysis` tool is #6. Left open pending review of this PR.
- #6 ships `xbe_min.py`, a second XBE parser duplicating `tools/xbe_parser`. It works; folding them together is a reasonable follow-up, not a merge blocker.
- PR #5 is untouched — it's already fully contained in `research/ms-fusion-recompiler`.
- The x87-global change in #9 overlaps `4a9adbf` on the research branch, which uses `RECOMP_TLS`. That's the better version; expect a small conflict there when the branches meet, resolved in favour of the TLS one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZDe6qTWAvohfDtYXbpRyM