### PR TITLE
fix(disasm): detect stored code pointers

### DIFF
--- a/tools/disasm/config.py
+++ b/tools/disasm/config.py
@@ -118,6 +118,7 @@ CONFIDENCE_PROLOGUE = 0.95   # Standard prologue pattern
 CONFIDENCE_CALL_TARGET = 0.90  # Destination of a call instruction
 CONFIDENCE_TAIL_JUMP = 0.88   # Target of a jmp that leaves its function
 CONFIDENCE_CC_BOUNDARY = 0.85  # After CC padding run following ret
+CONFIDENCE_CODE_POINTER = 0.80  # Code address stored as an immediate
 
 # ============================================================
 # Disassembly Engine Settings

--- a/tools/disasm/functions.py
+++ b/tools/disasm/functions.py
@@ -112,10 +112,13 @@ class FunctionDetector:
         # Pass 4: Call targets
         self._pass_call_targets(sections)
 
-        # Pass 5: Build functions from candidates
+        # Pass 5: Code addresses stored as immediates
+        self._pass_code_pointers()
+
+        # Pass 6: Build functions from candidates
         self._build_functions(sections)
 
-        # Pass 6: Tail-jump targets. A function reached only by "jmp" and never
+        # Pass 7: Tail-jump targets. A function reached only by "jmp" and never
         # by "call" is invisible to every pass above, so it is emitted as a stub
         # that returns without unwinding the frame its jumping caller built --
         # silently corrupting the simulated stack for everything upstream. Halo
@@ -377,6 +380,29 @@ class FunctionDetector:
                 detection_method="tail_jump_alias",
                 num_instructions=len(insns),
                 has_prologue=False,
+            )
+
+    def _pass_code_pointers(self) -> None:
+        """Add stored code addresses as function-start candidates.
+
+        Callbacks stored in tables are not direct call targets, so the other
+        detection passes can miss them. Requiring an existing instruction
+        boundary in an executable section avoids promoting ordinary integer or
+        data addresses.
+        """
+        for insn in self.engine.instructions.values():
+            target = insn.imm_ref
+            if target is None or target in self._candidates:
+                continue
+            if target not in self.engine.instructions:
+                continue
+            section = self.image.get_section_at_va(target)
+            if section is None or not section.executable:
+                continue
+            self._add_candidate(
+                target,
+                config.CONFIDENCE_CODE_POINTER,
+                "code_pointer",
             )
 
     def _build_functions(self, sections: List[SectionInfo]) -> None:

--- a/tools/disasm/test_code_pointer_targets.py
+++ b/tools/disasm/test_code_pointer_targets.py
@@ -1,0 +1,77 @@
+"""Regression tests for function pointers stored as immediates."""
+
+from tools.disasm import config
+from tools.disasm.engine import DisasmEngine
+from tools.disasm.functions import FunctionDetector
+from tools.disasm.labels import LabelManager
+from tools.disasm.loader import BinaryImage, SectionInfo
+from tools.disasm.xrefs import XRefTracker
+
+
+BASE = 0x00011000
+DATA_ADDRESS = 0x009D9DBC
+
+
+def _imm32(value):
+    return value.to_bytes(4, "little")
+
+
+def _detect(body):
+    text = SectionInfo(
+        name=".text",
+        virtual_addr=BASE,
+        virtual_size=len(body),
+        raw_addr=0,
+        raw_size=len(body),
+        writable=False,
+        executable=True,
+        flags="",
+    )
+    image = BinaryImage(
+        filepath="<synthetic>",
+        raw_data=bytes(body),
+        base_address=BASE,
+        image_size=len(body),
+        entry_point=BASE,
+        kernel_thunk_addr=0,
+        sections=[text],
+    )
+    engine = DisasmEngine(image)
+    engine.linear_sweep(text)
+    detector = FunctionDetector(
+        engine, image, XRefTracker(), LabelManager())
+    detector.detect_all([text])
+    return detector
+
+
+def test_stored_code_pointer_becomes_function_candidate():
+    callback = BASE + 0x20
+    body = bytearray(b"\x90" * 0x40)
+    body[0x00:0x03] = b"\x55\x8B\xEC"  # push ebp; mov ebp, esp
+    body[0x03:0x0D] = (
+        b"\xC7\x05" + _imm32(DATA_ADDRESS) + _imm32(callback))
+    body[0x0D] = 0xC3
+    body[0x20:0x23] = b"\x83\xF8\x05"  # cmp eax, 5
+    body[0x23] = 0xC3
+
+    detector = _detect(body)
+
+    assert callback in detector.functions
+    confidence, method = detector._candidates[callback]
+    assert confidence == config.CONFIDENCE_CODE_POINTER
+    assert method == "code_pointer"
+
+
+def test_immediate_must_land_on_an_instruction_boundary():
+    middle_of_instruction = BASE + 0x22
+    body = bytearray(b"\x90" * 0x40)
+    body[0x00:0x03] = b"\x55\x8B\xEC"
+    body[0x03:0x08] = b"\xB8" + _imm32(middle_of_instruction)
+    body[0x08] = 0xC3
+    body[0x20:0x25] = b"\x3D" + _imm32(BASE)
+    body[0x25] = 0xC3
+
+    detector = _detect(body)
+
+    assert middle_of_instruction not in detector.functions
+    assert middle_of_instruction not in detector._candidates


### PR DESCRIPTION
## Problem

The function detector can miss callbacks that appear only as stored addresses. These functions have no direct call target, standard prologue, or padding boundary.

A missed callback does not enter the function database or dispatch table. A later indirect call can then resolve to no function.

## Change

This PR adds a code-pointer detection pass before function bodies are built.

The pass reads `Instruction.imm_ref` values and accepts a target only when both conditions are true:

- The target is an existing decoded instruction boundary.
- The target is inside an executable section.

Accepted targets use the new `code_pointer` method with confidence `0.80`. Higher-confidence evidence still wins through the existing candidate merge logic.

## False-positive controls

The pass does not decode new bytes or promote every in-range integer. It rejects data addresses and addresses inside an instruction.

The pass also leaves existing entry-point, prologue, call-target, and tail-jump behavior unchanged.

## Tests

The synthetic tests cover these cases:

- A stored callback address becomes a function candidate.
- The candidate records the expected method and confidence.
- An address inside an instruction does not become a candidate.

## Validation

- `python -m pytest tools -q`: 144 passed, 5 subtests passed.
- `python -m tools.conformance`: 2,779 instruction vectors and 211 function vectors, 0 mismatches.