### PR TITLE
fix(lifter): lift xlat table lookups

### DIFF
--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -980,6 +980,15 @@ class Lifter:
             return [f"/* bt {insn.op_str} */"]
         if m == "emms":
             return ["/* emms - empty MMX state */"]
+        if m in ("xlat", "xlatb"):
+            # AL indexes the byte table at EBX. With an address-size override,
+            # the effective offset is calculated and wrapped at 16 bits.
+            raw_bytes = bytes.fromhex(insn.bytes_hex)
+            if 0x67 in raw_bytes[:-1]:
+                address = "(uint16_t)(LO16(ebx) + LO8(eax))"
+            else:
+                address = "ebx + LO8(eax)"
+            return [f"SET_LO8(eax, MEM8({address})); /* xlatb */"]
         if m in ("sete", "setne", "setb", "setae", "setbe", "seta",
                  "setl", "setge", "setle", "setg", "sets", "setns"):
             return self._lift_setcc(insn, ops, m)

--- a/tools/recomp/test_lifter_xlat.py
+++ b/tools/recomp/test_lifter_xlat.py
@@ -1,0 +1,20 @@
+"""Tests for XLAT/XLATB lifting."""
+
+from tools.recomp.lifter import Instruction, Lifter
+
+
+def test_xlat_uses_ebx_and_zero_extended_al():
+    insn = Instruction(0x1000, 1, "xlatb", "", "d7")
+
+    assert Lifter().lift_instruction(insn) == [
+        "SET_LO8(eax, MEM8(ebx + LO8(eax))); /* xlatb */",
+    ]
+
+
+def test_address_size_override_uses_wrapped_bx_address():
+    insn = Instruction(0x1000, 2, "xlatb", "", "67d7")
+
+    assert Lifter().lift_instruction(insn) == [
+        "SET_LO8(eax, MEM8((uint16_t)(LO16(ebx) + LO8(eax)))); "
+        "/* xlatb */",
+    ]


### PR DESCRIPTION
## Problem

The lifter treats `XLAT` and `XLATB` as unhandled instructions. Generated code therefore leaves `AL` unchanged when the guest performs a table lookup.

## Change

This PR lifts the instruction with its x86-32 behavior:

```c
AL = MEM8(EBX + zero_extend(AL));
```

The generated form uses `SET_LO8`, so the write changes only `AL`. The other bits in `EAX` remain unchanged.

The address-size prefix `0x67` selects 16-bit addressing. In that form, the lifter uses `BX` and wraps the effective offset to 16 bits.

## Scope

The change handles both Capstone mnemonic forms, `xlat` and `xlatb`. It does not change other memory or prefix handling.

## Tests

The tests cover these cases:

- The default form reads from `EBX + zero_extend(AL)`.
- The address-size override uses `BX`.
- The 16-bit effective offset wraps before the memory read.
- The result writes only the low byte of `EAX`.

## Validation

- `python -m pytest tools -q`: 144 passed, 5 subtests passed.
- `python -m tools.conformance`: 2,779 instruction vectors and 211 function vectors, 0 mismatches.