### PR TITLE
fix(recomp): route manual calls through lookup

### DIFF
--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -672,6 +672,10 @@ def _emit_cond_goto(cond_expr, jcc, desc, target, lifter):
     if lifter and lifter._is_external_target(target):
         # Conditional tail call: same frame bridge as the unconditional tail
         # jmp in _lift_jmp, applied only on the taken path.
+        if target in lifter.manual_functions:
+            return (f"if ({cond_expr}) {{ g_seh_ebp = ebp; "
+                    f"RECOMP_ITAIL(0x{target:08X}u); return; }}"
+                    f" /* {jcc}: {desc}, manual tail */")
         name = lifter._call_target_name(target)
         return (f"if ({cond_expr}) {{ g_seh_ebp = ebp; {name}(); return; }}"
                 f" /* {jcc}: {desc} */")
@@ -789,18 +793,20 @@ class Lifter:
     """Translates x86 instructions to C statements."""
 
     def __init__(self, func_db=None, label_db=None, abi_db=None, xbe_data=None,
-                 seh_prolog=None, seh_epilog=None):
+                 seh_prolog=None, seh_epilog=None, manual_functions=None):
         """
         func_db: dict of func_addr → func_info (for naming call targets)
         label_db: dict of addr → name (for kernel imports, etc.)
         abi_db: dict of addr → ABI info (for calling conventions)
         xbe_data: raw XBE file bytes (for reading jump tables)
         seh_prolog/seh_epilog: override the detected __SEH_prolog/__SEH_epilog
+        manual_functions: addresses replaced through recomp_lookup_manual
         """
         self.func_db = func_db or {}
         self.label_db = label_db or {}
         self.abi_db = abi_db or {}
         self.xbe_data = xbe_data
+        self.manual_functions = set(manual_functions or ())
         self._fp_top = 0  # FPU stack top index
         self.func_start = 0  # Set per-function by translator
         self.func_end = 0
@@ -1384,7 +1390,6 @@ class Lifter:
         # value -- so writing the true address costs nothing at the return side.
         ret_va = insn.end_address
         if insn.call_target:
-            name = self._call_target_name(insn.call_target)
             lines = []
             # Re-publish this function's frame before every call, not just once
             # at `mov ebp, esp`. g_ebp is "the last frame established anywhere",
@@ -1396,9 +1401,17 @@ class Lifter:
             # [ebp-0xa0] onto Xbox VA 4 and 6: exactly the fs:[4] corruption.
             if self.publishes_ebp:
                 lines.append("g_ebp = ebp; /* frame stays current across calls */")
-            lines.append(
-                f"PUSH32(esp, 0x{ret_va:08X}u); {name}(); "
-                f"/* call 0x{insn.call_target:08X} */")
+            if insn.call_target in self.manual_functions:
+                lines.append(
+                    f"PUSH32(esp, 0x{ret_va:08X}u); "
+                    f"RECOMP_ICALL_SAFE(0x{insn.call_target:08X}u, "
+                    "_icall_esp); "
+                    f"/* manual call 0x{insn.call_target:08X} */")
+            else:
+                name = self._call_target_name(insn.call_target)
+                lines.append(
+                    f"PUSH32(esp, 0x{ret_va:08X}u); {name}(); "
+                    f"/* call 0x{insn.call_target:08X} */")
             # esp immediately after the callee returns. A per-call delta is the
             # only way to attribute a leak to one callee rather than to the
             # function containing them all.
@@ -1513,6 +1526,19 @@ class Lifter:
             if self._is_external_target(insn.jump_target):
                 # Tail call - no return address push (reuses current frame's)
                 # Bridge ebp so the target function can inherit our frame pointer.
+                if insn.jump_target in self.manual_functions:
+                    tail = (
+                        f"g_seh_ebp = ebp; "
+                        f"RECOMP_ITAIL(0x{insn.jump_target:08X}u); return; "
+                        f"/* manual tail jmp 0x{insn.jump_target:08X} */"
+                    )
+                    if self.trace_exit_name:
+                        return [
+                            f'RECOMP_TRACE_ESP("{self.trace_exit_name}", '
+                            f'"tail 0x{insn.jump_target:08X}");',
+                            tail,
+                        ]
+                    return [tail]
                 name = self._call_target_name(insn.jump_target)
                 tail = (f"g_seh_ebp = ebp; {name}(); return; "
                         f"/* tail jmp 0x{insn.jump_target:08X} */")

--- a/tools/recomp/test_manual_call_dispatch.py
+++ b/tools/recomp/test_manual_call_dispatch.py
@@ -1,0 +1,122 @@
+"""Tests for calls to functions replaced through manual dispatch."""
+
+import tempfile
+
+from tools.recomp.disasm import BasicBlock, Instruction, Operand
+from tools.recomp.lifter import Lifter, lift_basic_block
+from tools.recomp.translator import BatchTranslator, _fixup_icall_esp_save
+
+
+TARGET = 0x001E9100
+
+
+def _direct_call(target=TARGET):
+    insn = Instruction(0x00120000, 5, "call", f"0x{target:x}", "e800000000")
+    insn.call_target = target
+    return insn
+
+
+def _tail_jump(target=TARGET):
+    insn = Instruction(0x00120000, 5, "jmp", f"0x{target:x}", "e900000000")
+    insn.jump_target = target
+    return insn
+
+
+def test_selected_direct_call_uses_manual_lookup():
+    lifted = Lifter(manual_functions={TARGET}).lift_instruction(_direct_call())
+    generated = "\n".join(lifted)
+
+    assert "PUSH32(esp, 0x00120005u);" in generated
+    assert "RECOMP_ICALL_SAFE(0x001E9100u, _icall_esp)" in generated
+    assert "sub_001E9100();" not in generated
+
+
+def test_unselected_direct_call_remains_direct():
+    lifted = Lifter().lift_instruction(_direct_call())
+    generated = "\n".join(lifted)
+
+    assert "sub_001E9100();" in generated
+    assert "RECOMP_ICALL_SAFE" not in generated
+
+
+def test_selected_tail_jump_uses_manual_lookup():
+    lifter = Lifter(manual_functions={TARGET})
+    lifter.func_start = 0x00120000
+    lifter.func_end = 0x00120100
+
+    generated = "\n".join(lifter.lift_instruction(_tail_jump()))
+
+    assert "RECOMP_ITAIL(0x001E9100u)" in generated
+    assert "sub_001E9100();" not in generated
+
+
+def test_selected_tail_jump_keeps_exit_trace():
+    lifter = Lifter(manual_functions={TARGET})
+    lifter.func_start = 0x00120000
+    lifter.func_end = 0x00120100
+    lifter.trace_exit_name = "sub_00120000"
+
+    generated = "\n".join(lifter.lift_instruction(_tail_jump()))
+
+    assert 'RECOMP_TRACE_ESP("sub_00120000", "tail 0x001E9100")' in generated
+
+
+def test_selected_conditional_tail_uses_manual_lookup():
+    compare = Instruction(0x00120000, 2, "cmp", "eax, ecx", "39c8")
+    compare.operands = [
+        Operand(type="reg", reg="eax"),
+        Operand(type="reg", reg="ecx"),
+    ]
+    jump = Instruction(
+        0x00120002, 6, "je", f"0x{TARGET:x}", "0f8400000000")
+    jump.jump_target = TARGET
+    lifter = Lifter(manual_functions={TARGET})
+    lifter.func_start = 0x00120000
+    lifter.func_end = 0x00120100
+
+    generated, _ = lift_basic_block(
+        lifter, BasicBlock(start=0x00120000, instructions=[compare, jump]))
+    output = "\n".join(generated)
+
+    assert "RECOMP_ITAIL(0x001E9100u)" in output
+    assert "sub_001E9100();" not in output
+
+
+def test_direct_manual_call_saves_esp_before_argument_pushes():
+    lines = [
+        "    PUSH32(esp, ecx);",
+        "    PUSH32(esp, 0x00120005u); "
+        "RECOMP_ICALL_SAFE(0x001E9100u, _icall_esp); "
+        "/* manual call 0x001E9100 */",
+    ]
+
+    fixed = _fixup_icall_esp_save(lines)
+    save = next(i for i, line in enumerate(fixed) if "_icall_esp = g_esp" in line)
+    argument = next(i for i, line in enumerate(fixed) if line.strip() == "PUSH32(esp, ecx);")
+
+    assert save < argument
+
+
+def test_split_translation_passes_manual_set_to_lifter():
+    class FakeTranslator:
+        def __init__(self):
+            self.owned_function_starts = set()
+            self.lifter = Lifter()
+            self.seen_manual = None
+
+        def translate_function(self, addr, func_info):
+            self.seen_manual = self.lifter.manual_functions
+            return f"void {func_info['name']}(void) {{}}"
+
+    batch = BatchTranslator.__new__(BatchTranslator)
+    batch.translator = FakeTranslator()
+    functions = [
+        (0x00120000, {"name": "sub_00120000"}),
+        (TARGET, {"name": "sub_001E9100"}),
+    ]
+
+    with tempfile.TemporaryDirectory() as output_dir:
+        batch.translate_batch_split(
+            functions, output_dir, manual={TARGET})
+
+    assert batch.translator.seen_manual == {TARGET}

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -1119,6 +1119,8 @@ class BatchTranslator:
         are still declared and still count as defined for stub purposes. This
         is how a game replaces a recompiled XDK routine (a D3D8 entry point,
         say) with one that drives the host runtime instead of the hardware.
+        Direct calls and tail jumps to these addresses use the same manual-first
+        lookup as indirect calls, so every call path reaches the override.
 
         Returns dict with stats and list of generated files.
         """
@@ -1129,6 +1131,7 @@ class BatchTranslator:
         func_list = [item for item in func_list
                      if item[0] not in self.translator.owned_function_starts]
         manual = set(manual or ())
+        self.translator.lifter.manual_functions = manual
         manual_decls = {}
 
         # Translate all functions first, collecting results


### PR DESCRIPTION
## Problem

Indirect calls already check `recomp_lookup_manual()` before generated dispatch. Direct calls and tail jumps do not use that lookup.

The translator emits those paths as direct C calls. A registered manual replacement can therefore work through a function pointer but be bypassed by a direct caller.

The existing `--manual-functions` and `--exclude-manual` options already identify replaced addresses. Before this PR, the lifter did not receive that address set.

## Change

This PR passes the existing manual-function set into the lifter. It applies manual-first lookup to each selected control-flow path:

- A direct call uses `RECOMP_ICALL_SAFE` with the real guest return address.
- An unconditional external jump uses `RECOMP_ITAIL`.
- A conditional external jump uses `RECOMP_ITAIL` only on the taken path.

Calls to addresses outside the manual-function set keep their current direct C calls.

## Stack and frame behavior

The existing `_fixup_icall_esp_save` pass saves `ESP` before argument pushes for a selected direct call.

Selected calls keep the current frame publication behavior. Selected tail jumps also keep exit tracing and the `g_seh_ebp` frame bridge.

## Interface scope

This PR uses the existing manual-function inputs as the single source of truth. It adds no target file, hash option, receipt format, or project-specific policy.

## Tests

The tests cover these cases:

- Selected direct calls use manual lookup.
- Unselected direct calls remain direct.
- Unconditional and conditional tails use manual lookup.
- Direct calls push the correct guest return address.
- The `ESP` save occurs before argument pushes.
- Tail jumps keep exit tracing.
- Split translation passes the manual-function set into the lifter.

## Validation

- `python -m pytest tools -q`: 149 passed, 5 subtests passed.
- `python -m tools.conformance`: 2,779 instruction vectors and 211 function vectors, 0 mismatches.