### PR TITLE
fix(lifter): implement bit scan instructions

### DIFF
--- a/tools/conformance/cases.py
+++ b/tools/conformance/cases.py
@@ -151,6 +151,12 @@ CASES = [
     Case("inc_dec", "inc/dec leave CF alone -- a classic place to get flags wrong",
          ["stc", "inc eax", "adc ecx, 0", "mov eax, ecx"], _PAIRS),
     Case("bswap", "byte swap", ["bswap eax"], _PAIRS),
+    Case("bsf", "least-significant set bit, with a nonzero source",
+         ["or ecx, 1", "bsf eax, ecx"], _PAIRS),
+    Case("bsr", "most-significant set bit, with a nonzero source",
+         ["or ecx, 1", "bsr eax, ecx"], _PAIRS),
+    Case("bit_scan_zf", "bit scan sets ZF when its source is zero",
+         ["bsf edx, ecx", "setz al", "movzx eax, al"], _PAIRS),
     Case("not_and", "bitwise", ["not eax", "and eax, ecx"], _PAIRS),
 
     # ══ x87 ═════════════════════════════════════════════════════════════════

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -598,12 +598,10 @@ def _make_condition(jcc, flag_setter, flag_ops):
 
     # ── bsf/bsr: bit scan, ZF set if source is zero ──
     if flag_setter in ("bsf", "bsr"):
-        if rhs is None:
-            return None
         if jcc in ("je", "jz"):
-            return f"({rhs} == 0)", desc
+            return "_flags", desc
         if jcc in ("jne", "jnz"):
-            return f"({rhs} != 0)", desc
+            return "!_flags", desc
         return None
 
     # ── bt/bts/btr/btc: bit test, sets CF ──
@@ -804,6 +802,7 @@ class Lifter:
         self._fp_top = 0  # FPU stack top index
         self.func_start = 0  # Set per-function by translator
         self.func_end = 0
+        self.needs_flags = True  # Translator disables snapshots with no consumer
         self.needs_cf = False  # Set per-function by translator (has adc/sbb)
         self.publishes_ebp = False  # Set per-function: has a real frame
         self.trace_exit_name = None  # Set per-function when traced
@@ -900,6 +899,8 @@ class Lifter:
             return self._lift_sar(insn, ops)
         if m in ("rol", "ror"):
             return self._lift_rotate(insn, ops, m)
+        if m in ("bsf", "bsr"):
+            return self._lift_bit_scan(ops, m)
 
         # ── Comparison / test (standalone, not part of cmp+jcc pattern) ──
         if m == "cmp":
@@ -1299,6 +1300,39 @@ class Lifter:
         cnt = _fmt_operand_read(ops[1])
         func = "ROL32" if m == "rol" else "ROR32"
         return [_fmt_operand_write(ops[0], f"{func}({dst}, {cnt})")]
+
+    def _lift_bit_scan(self, ops, mnemonic):
+        if len(ops) < 2:
+            return [f"/* {mnemonic}: bad operands */"]
+
+        src = _fmt_operand_read(ops[1])
+        width = _operand_width(ops[1]) or _operand_width(ops[0]) or 4
+        bits = width * 8
+        value = (f"(uint32_t)(uint16_t)({src})" if width == 2
+                 else f"(uint32_t)({src})")
+        if mnemonic == "bsr":
+            initial_index = bits - 1
+            step = "--_bs_index"
+        else:
+            initial_index = 0
+            step = "++_bs_index"
+        write = _fmt_operand_write(ops[0], "_bs_index")
+        statements = [
+            "{",
+            f"    uint32_t _bs_value = {value};",
+        ]
+        if self.needs_flags:
+            statements.append("    _flags = (_bs_value == 0);")
+        statements.extend([
+            "    if (_bs_value != 0) {",
+            f"        uint32_t _bs_index = {initial_index};",
+            "        while (((_bs_value >> _bs_index) & 1u) == 0u) "
+            f"{step};",
+            f"        {write}",
+            "    }",
+            f"}} /* {mnemonic} */",
+        ])
+        return statements
 
     # ── Compare / Test (standalone) ──
 

--- a/tools/recomp/test_lifter_bit_scan.py
+++ b/tools/recomp/test_lifter_bit_scan.py
@@ -1,0 +1,86 @@
+"""Tests for BSF/BSR lifting and their zero flag."""
+
+from tools.recomp.disasm import BasicBlock, Instruction, Operand
+from tools.recomp.lifter import Lifter, lift_basic_block
+
+
+def _reg(name):
+    return Operand(type="reg", reg=name)
+
+
+def test_lifts_32_bit_bsf():
+    insn = Instruction(0, 3, "bsf", "eax, ecx", "0fbcc1")
+    insn.operands = [_reg("eax"), _reg("ecx")]
+
+    generated = "\n".join(Lifter().lift_instruction(insn))
+
+    assert "uint32_t _bs_index = 0;" in generated
+    assert "eax = _bs_index;" in generated
+    assert "_flags = (_bs_value == 0);" in generated
+
+
+def test_lifts_16_bit_bsr_without_clobbering_upper_bits():
+    insn = Instruction(0, 4, "bsr", "ax, word ptr [ecx]", "660fbd01")
+    insn.operands = [
+        _reg("ax"),
+        Operand(type="mem", mem_base="ecx", mem_size=2),
+    ]
+
+    generated = "\n".join(Lifter().lift_instruction(insn))
+
+    assert "uint32_t _bs_index = 15;" in generated
+    assert "SET_LO16(eax, _bs_index);" in generated
+
+
+def test_preserves_destination_when_source_is_zero():
+    insn = Instruction(0, 3, "bsf", "eax, ecx", "0fbcc1")
+    insn.operands = [_reg("eax"), _reg("ecx")]
+
+    generated = "\n".join(Lifter().lift_instruction(insn))
+
+    assert "if (_bs_value != 0) {" in generated
+    assert "eax = _bs_index;" in generated
+
+
+def test_omits_zero_flag_snapshot_when_function_has_no_consumer():
+    insn = Instruction(0, 3, "bsf", "eax, ecx", "0fbcc1")
+    insn.operands = [_reg("eax"), _reg("ecx")]
+    lifter = Lifter()
+    lifter.needs_flags = False
+
+    generated = "\n".join(lifter.lift_instruction(insn))
+
+    assert "_flags" not in generated
+
+
+def test_jz_reads_snapshotted_zero_flag_after_source_is_clobbered():
+    scan = Instruction(0, 3, "bsf", "eax, ecx", "0fbcc1")
+    scan.operands = [_reg("eax"), _reg("ecx")]
+    move = Instruction(3, 5, "mov", "ecx, 1", "b901000000")
+    move.operands = [_reg("ecx"), Operand(type="imm", imm=1)]
+    jump = Instruction(8, 2, "je", "0x10", "7406")
+    jump.jump_target = 0x10
+
+    lifter = Lifter()
+    lifter.func_start = 0
+    lifter.func_end = 0x20
+    generated, _ = lift_basic_block(
+        lifter, BasicBlock(start=0, instructions=[scan, move, jump]))
+
+    assert "if (_flags) goto loc_00000010;" in generated[-1]
+    assert all("ecx == 0" not in statement for statement in generated)
+
+
+def test_jnz_reads_snapshotted_zero_flag():
+    scan = Instruction(0, 3, "bsr", "eax, ecx", "0fbdc1")
+    scan.operands = [_reg("eax"), _reg("ecx")]
+    jump = Instruction(3, 2, "jne", "0x10", "750b")
+    jump.jump_target = 0x10
+
+    lifter = Lifter()
+    lifter.func_start = 0
+    lifter.func_end = 0x20
+    generated, _ = lift_basic_block(
+        lifter, BasicBlock(start=0, instructions=[scan, jump]))
+
+    assert "if (!_flags) goto loc_00000010;" in generated[-1]

--- a/tools/recomp/translator.py
+++ b/tools/recomp/translator.py
@@ -662,6 +662,7 @@ class FunctionTranslator:
             for insn in instructions)
         if has_conditionals:
             lines.append(f"    int _flags = 0; /* fallback flag var */")
+        self.lifter.needs_flags = has_conditionals
 
         # Flag snapshot temporaries: a cmp/test records its operands here,
         # zero- and sign-extended to the compare's own width, so the branch


### PR DESCRIPTION
## Problem

The lifter recognizes `BSF` and `BSR` as flag setters but does not lift their result. The generated body contains an unhandled-instruction comment.

The old branch logic also reads the source operand again when it evaluates `ZF`. A flag-preserving instruction can change that source before `JZ` or `JNZ`.

## Change

This PR implements 16-bit and 32-bit bit scans.

For a nonzero source, `BSF` finds the least-significant set bit. `BSR` finds the most-significant set bit.

For a zero source, the destination stays unchanged. This matches the architectural rule that the destination is undefined and avoids inventing a value.

The lifter snapshots `ZF` when the bit scan runs. Later `JZ`, `JNZ`, `SETcc`, and `CMOVcc` consumers use that snapshot.

The translator disables the snapshot when the function has no flag consumer. This avoids an unused `_flags` dependency.

## Tests

The unit tests cover these cases:

- A 32-bit `BSF` result.
- A 16-bit `BSR` result without damage to the upper register bits.
- An unchanged destination for a zero source.
- `JZ` after a flag-preserving source-register write.
- `JNZ` from the saved zero flag.
- No flag snapshot when no consumer exists.

The conformance corpus also executes `BSF`, `BSR`, and the zero-flag result on the native CPU.

## Validation

- `python -m pytest tools -q`: 148 passed, 5 subtests passed.
- `python -m tools.conformance`: 2,779 instruction vectors and 211 function vectors, 0 mismatches.