### PR TITLE
`ERROR_NOT_OWNER` not set in `ReleaseMutex`

### DIFF
--- a/src/platform/win32_compat.c
+++ b/src/platform/win32_compat.c
@@ -545,9 +545,17 @@ HANDLE CreateMutexW(LPSECURITY_ATTRIBUTES sa, BOOL initialOwner, LPCWSTR name)
 BOOL ReleaseMutex(HANDLE h)
 {
     w32_object *o = (w32_object *)h;
-    if (!o || o->kind != K_MUTEX) return FALSE;
+    if (!o || o->kind != K_MUTEX) {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return FALSE;
+    }
     pthread_mutex_lock(&o->lock);
-    if (o->mtx_owner == GetCurrentThreadId() && --o->mtx_recursion <= 0) {
+    if (o->mtx_owner != GetCurrentThreadId()) {
+        pthread_mutex_unlock(&o->lock);
+        SetLastError(ERROR_NOT_OWNER);
+        return FALSE;
+    }
+    if (--o->mtx_recursion <= 0) {
         o->mtx_owner = 0;
         o->mtx_recursion = 0;
         pthread_cond_broadcast(&o->cond);

--- a/src/platform/win32_compat.h
+++ b/src/platform/win32_compat.h
@@ -361,6 +361,7 @@ int   WideCharToMultiByte(UINT cp, DWORD flags, LPCWSTR wide, int wideCount,
 #define ERROR_INSUFFICIENT_BUFFER     122u
 #define ERROR_ALREADY_EXISTS          183u
 #define ERROR_MORE_DATA               234u
+#define ERROR_NOT_OWNER               288u
 #define ERROR_MR_MID_NOT_FOUND        317u
 #define ERROR_IO_PENDING              997u
 #define ERROR_CANCELLED               1223u


### PR DESCRIPTION
`xbox_NtReleaseMutant` checks for `ERROR_NOT_OWNER` but `ERROR_NOT_OWNER` is never defined for POSIX and never set