### PR TITLE
Add MacOS stubs and build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ game_files/
 *.xiso
 
 # IDE
+.vs/
 .vscode/
 .idea/
 *.suo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,12 @@ py -3 -m pytest tools/       # unit tests
 py -3 -m tools.conformance   # differential: lifted C vs the real CPU
 ```
 
+Run unit tests on MacOS
+
+```bash
+bash tools/macos/run_tests.sh
+```
+
 The unit tests are fast and need no game files — the lifter tests assemble real byte
 sequences and check the C that comes out. If you fix a lift, add the case.
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The recompiler output (`tools/recomp`) generates these automatically. The xboxre
 ### Prerequisites
 
 - **Windows 11/10** (D3D11 backend) — or **Linux** (OpenGL backend; `tools/linux/install_deps.sh`)
+- **macOS**: install the native libraries required by the OpenGL backend with `brew install sdl2 libepoxy`
 - **Python 3.10+** with `capstone` (`pip install capstone`)
 - **Visual Studio 2022** (MSVC compiler)
 - **CMake 3.20+**
@@ -410,6 +411,11 @@ That's it for the core pipeline — no IDA, no Ghidra, no proprietary tools. Jus
 ```
 py -3 -m pytest tools/       # unit tests
 py -3 -m tools.conformance   # differential: lifted C vs the real CPU
+```
+
+Run unit tests on MacOS
+```bash
+bash tools/macos/run_tests.sh
 ```
 
 The unit tests are fast and need no game files. The conformance suite goes

--- a/src/kernel/kernel_memory.c
+++ b/src/kernel/kernel_memory.c
@@ -10,7 +10,10 @@
  */
 
 #include "kernel.h"
+#if defined(_WIN32)
+/* _aligned_malloc/_aligned_free; POSIX gets them from win32_compat.h */
 #include <malloc.h>
+#endif
 
 /* ============================================================================
  * Helper: Xbox protect flags → Win32 protect flags

--- a/src/kernel/kernel_rtl.c
+++ b/src/kernel/kernel_rtl.c
@@ -34,7 +34,7 @@ VOID __stdcall xbox_RtlInitAnsiString(PXBOX_ANSI_STRING DestinationString, const
 VOID __stdcall xbox_RtlInitUnicodeString(PXBOX_UNICODE_STRING DestinationString, const WCHAR* SourceString)
 {
     if (SourceString) {
-        USHORT len = (USHORT)(wcslen(SourceString) * sizeof(WCHAR));
+        USHORT len = (USHORT)(xbox_wcslen(SourceString) * sizeof(WCHAR));
         DestinationString->Length = len;
         DestinationString->MaximumLength = len + sizeof(WCHAR);
         DestinationString->Buffer = (PWCHAR)SourceString;

--- a/src/nv2a/nv2a_pgraph_d3d11.c
+++ b/src/nv2a/nv2a_pgraph_d3d11.c
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <math.h>
 
 /* D3D8 device — we include the full header for COM vtable access */

--- a/src/platform/win32_compat.c
+++ b/src/platform/win32_compat.c
@@ -5,7 +5,7 @@
  * (threads/events/mutexes/atomics/heap/timers) -- it carries no Xbox
  * semantics. The Xbox kernel HLE in src/kernel builds on top of it.
  *
- * Linux/POSIX only.
+ * POSIX (Linux/MacOS) only.
  */
 
 #if !defined(_WIN32)
@@ -26,7 +26,13 @@
 #include <sched.h>
 #include <fenv.h>
 #include <sys/mman.h>
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/stat.h>
+#include <mach/mach.h>
+#else
 #include <sys/sysinfo.h>
+#endif
 
 /* ===================================================================== */
 /* Last-error (thread-local)                                             */
@@ -904,10 +910,20 @@ LPVOID VirtualAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD pro
         /* fall through to a fresh mapping */
     }
 
+#if defined(MAP_FIXED_NOREPLACE)
     if (address) flags |= MAP_FIXED_NOREPLACE;
+#elif defined(__APPLE__)
+    /* TODO: mach_vm_map with VM_FLAGS_FIXED (which does fail rather than replace),
+     * or a mach_vm_region probe before an MAP_FIXED call. */
+#endif
     void *p = mmap(address, size, prot ? prot : PROT_READ | PROT_WRITE,
                    flags, -1, 0);
     if (p == MAP_FAILED) { SetLastError(8); return NULL; }
+#if !defined(MAP_FIXED_NOREPLACE)
+    /* TODO: Without MAP_FIXED_NOREPLACE (macOS or older kernels) plain
+     * MAP_FIXED would silently unmap whatever already lives there. Getting a
+     * different address means the range was taken: fail as Linux does. */
+#endif
     return p;
 }
 
@@ -1010,7 +1026,29 @@ VOID OutputDebugStringA(LPCSTR str)
 
 VOID ExitProcess(UINT exitCode) { exit((int)exitCode); }
 
-VOID SecureZeroMemory(PVOID ptr, SIZE_T cnt) { explicit_bzero(ptr, cnt); }
+BOOL IsDebuggerPresent(void)
+{
+#if defined(__APPLE__)
+    /* TODO: Darwin: KERN_PROC_PID reports P_TRACED when a debugger is attached. */
+    return FALSE;
+#else
+    /* TODO: On Linux a non-zero TracerPid in /proc/self/status means ptrace is attached. */
+    return FALSE;
+#endif
+}
+
+VOID DebugBreak(void) {
+    // TODO: Use __debugbreak()?
+}
+
+VOID SecureZeroMemory(PVOID ptr, SIZE_T cnt)
+{
+#if defined(__APPLE__)
+    // TODO: Darwin explicit_bzero equivalent is memset_s.
+#else
+    explicit_bzero(ptr, cnt);
+#endif
+}
 
 unsigned int _clearfp(void)
 {
@@ -1253,6 +1291,18 @@ static size_t view_take(const void *addr)
     return len;
 }
 
+/* An unnamed file descriptor that ftruncate and mmap both accept. Linux has
+ * memfd_create for this; elsewhere an immediately-unlinked temp file does. */
+static int anon_map_fd(const char *name)
+{
+#if defined(__APPLE__)
+    // TODO: use shm_open on macOS 10.12+ or mkstemp + unlink for older versions
+    return 0;
+#else
+    return memfd_create(name ? name : "xbox_map", 0);
+#endif
+}
+
 HANDLE CreateFileMappingA(HANDLE file, LPSECURITY_ATTRIBUTES sa, DWORD protect,
                           DWORD maxSizeHigh, DWORD maxSizeLow, LPCSTR name)
 {
@@ -1260,7 +1310,7 @@ HANDLE CreateFileMappingA(HANDLE file, LPSECURITY_ATTRIBUTES sa, DWORD protect,
     SIZE_T size = ((SIZE_T)maxSizeHigh << 32) | maxSizeLow;
     if (size == 0) { SetLastError(ERROR_INVALID_PARAMETER); return NULL; }
 
-    int fd = memfd_create(name ? name : "xbox_map", 0);
+    int fd = anon_map_fd(name);
     if (fd < 0) { SetLastError(ERROR_NOT_ENOUGH_MEMORY); return NULL; }
     if (ftruncate(fd, (off_t)size) != 0) {
         close(fd);
@@ -1329,6 +1379,10 @@ SIZE_T VirtualQuery(LPCVOID address, PMEMORY_BASIC_INFORMATION buffer, SIZE_T le
 
 BOOL GlobalMemoryStatusEx(LPMEMORYSTATUSEX b)
 {
+#if defined(__APPLE__)
+    /* TODO: Darwin has no sysinfo(2): physical memory comes from sysctl, the free
+     * page count from the Mach VM statistics, swap from vm.swapusage. */
+#else
     struct sysinfo si;
     if (!b) return FALSE;
     if (sysinfo(&si) != 0) return FALSE;
@@ -1338,6 +1392,7 @@ BOOL GlobalMemoryStatusEx(LPMEMORYSTATUSEX b)
     b->ullAvailPhys     = (ULONGLONG)si.freeram   * unit;
     b->ullTotalPageFile = b->ullTotalPhys + (ULONGLONG)si.totalswap * unit;
     b->ullAvailPageFile = b->ullAvailPhys + (ULONGLONG)si.freeswap  * unit;
+#endif
     b->ullTotalVirtual  = b->ullTotalPhys;
     b->ullAvailVirtual  = b->ullAvailPhys;
     b->ullAvailExtendedVirtual = 0;

--- a/src/platform/win32_compat.h
+++ b/src/platform/win32_compat.h
@@ -8,7 +8,7 @@
  * honestly on POSIX so the Xbox-specific HLE code above it is unchanged and
  * stays verifiable.
  *
- * Linux-only: on Windows these come from the real <windows.h>.
+ * Linux/MacOS only: on Windows these come from the real <windows.h>.
  */
 
 #ifndef WIN32_COMPAT_H
@@ -198,6 +198,8 @@ BOOL  QueryPerformanceFrequency(PLARGE_INTEGER freq);
 VOID  OutputDebugStringA(LPCSTR str);
 VOID  OutputDebugStringW(LPCWSTR str);
 VOID  ExitProcess(UINT exitCode);
+BOOL  IsDebuggerPresent(void);
+VOID  DebugBreak(void);
 BOOL  TerminateProcess(HANDLE process, UINT exitCode);
 VOID  SecureZeroMemory(PVOID ptr, SIZE_T cnt);
 unsigned int _clearfp(void);   /* clear pending FPU exception flags */

--- a/tools/macos/run_tests.sh
+++ b/tools/macos/run_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required on macOS. Install Python 3.10+ and re-run this script." >&2
+    exit 1
+fi
+
+python3 -m pip install --user capstone pytest pefile numpy
+python3 -m pytest tools/ -q


### PR DESCRIPTION
Hooks already have `#if defined(_WIN32)` with the non-Windows path stubbed out — so macOS inherits the Linux situation there rather than a new blocker.

* Add build and test instructions
* malloc doesn't exist on Darwin and is unnecessary on POSIX
* Replacing `wcslen` with `xbox_wcslen` is the only functional change.

Per docs
```
/* ---- Wide-string helpers (operate on the 16-bit Xbox WCHAR) ----------
 * Named xbox_wcs* (not macros over wcs*) so they never collide with the
 * 32-bit-wchar_t CRT functions in <wchar.h>. On Windows xbox_winnt.h maps
 * these names to the real CRT functions. */
SIZE_T xbox_wcslen(const WCHAR *s);
```

Tested on M4 Mac Studio
Tested on Windows 11
Outputs statically compiled libraries
174 passed, 1 skipped in 1.11s