### PR TITLE
fix(lifter): clear stale carry after xor register zeroing

### DIFF
--- a/tools/conformance/cases.py
+++ b/tools/conformance/cases.py
@@ -107,6 +107,18 @@ CASES = [
     Case("testz_i16", "ZF from a 16-bit test",
          ["test ax, cx", "setz al", "movzx eax, al"], _PAIRS),
 
+    # -- xor zeroing must clear an incoming carry ----------------------------
+    Case("xor_self_adc_i8", "byte zeroing clears CF before adc",
+         ["stc", "xor cl, cl", "adc eax, 0"], [(a, 0) for a in _EDGES]),
+    Case("xor_self_adc_hi8", "high-byte zeroing clears CF before adc",
+         ["stc", "xor ch, ch", "adc eax, 0"], [(a, 0) for a in _EDGES]),
+    Case("xor_self_adc_i16", "word zeroing clears CF before adc",
+         ["stc", "xor cx, cx", "adc eax, 0"], [(a, 0) for a in _EDGES]),
+    Case("xor_self_adc_i32", "dword zeroing clears CF before adc",
+         ["stc", "xor ecx, ecx", "adc eax, 0"], [(a, 0) for a in _EDGES]),
+    Case("xor_self_sbb_i32", "dword zeroing clears CF before sbb",
+         ["stc", "xor ecx, ecx", "sbb eax, 0"], [(a, 0) for a in _EDGES]),
+
     # -- neg carry into a dependent sbb (PR #8) ------------------------------
     Case("neg_sbb_adjacent", "neg sets CF = (operand != 0); sbb consumes it",
          ["neg eax", "sbb ecx, ecx", "mov eax, ecx"], _PAIRS),

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -1420,7 +1420,9 @@ class Lifter:
         src = _fmt_operand_read(ops[1])
         # XOR reg, reg → zero
         if m == "xor" and ops[0].type == "reg" and ops[1].type == "reg" and ops[0].reg == ops[1].reg:
-            return [_fmt_operand_write(ops[0], "0") + " /* xor self */"]
+            out = ["_cf = 0; /* xor clears CF */"] if self.needs_cf else []
+            out.append(_fmt_operand_write(ops[0], "0") + " /* xor self */")
+            return out
         expr = f"{dst} {c_op} {src}"
         out = []
         if self.needs_cf:


### PR DESCRIPTION
`xor reg, reg` clears CF on x86, but the lifter's zeroing shortcut returned before the normal logical-operation carry update. With CF already set, `stc; xor ecx, ecx; adc eax, 0` incremented EAX in lifted C while native execution left it unchanged. A following SBB similarly subtracted an extra one.

Clear `_cf` in the zeroing shortcut when the function tracks carry, retaining the existing zero-register optimization. This extracts the useful part of the local carry work without its lookahead machinery or other local runtime changes.

Validation against upstream `a781596`:

- Added native-versus-lifted cases for low-byte, high-byte, word, and dword XOR zeroing followed by ADC, plus dword XOR followed by SBB. All 60 vectors failed before the fix.
- `python -m pytest tools/ -q`: 200 passed, 8 subtests passed.
- `python -m tools.conformance`: 4,879 instruction vectors and 211 function vectors; zero mismatches, using 32-bit MSVC.

No game was regenerated or run for this extracted patch. The regression cases use synthetic assembly and the real x86 CPU as the reference.

Independent PR; no prerequisites. Proposed merge shape: squash.
