### PR TITLE
fix(d3d): correct weighted FVF layouts and transformed-position detection

### DIFF
--- a/src/d3d/d3d8_fvf.h
+++ b/src/d3d/d3d8_fvf.h
@@ -1,0 +1,29 @@
+#ifndef XBOX_D3D8_FVF_H
+#define XBOX_D3D8_FVF_H
+
+#include "d3d8_xbox.h"
+
+static inline int d3d8_fvf_transformed(DWORD fvf)
+{
+    return (fvf & D3DFVF_POSITION_MASK) == D3DFVF_XYZRHW;
+}
+
+/* Position is an encoded field, not independent bits. Beta slots precede
+ * normals/colors even when the current shader does not consume weights. */
+static inline UINT d3d8_fvf_position_bytes(DWORD fvf)
+{
+    DWORD position = fvf & D3DFVF_POSITION_MASK;
+    switch (position) {
+    case D3DFVF_XYZ:    return 12;
+    case D3DFVF_XYZRHW: return 16;
+    case D3DFVF_XYZB1:
+    case D3DFVF_XYZB2:
+    case D3DFVF_XYZB3:
+    case D3DFVF_XYZB4:
+    case D3DFVF_XYZB5:
+        return 12 + 4 * ((position - D3DFVF_XYZRHW) / 2);
+    default: return 0;
+    }
+}
+
+#endif

--- a/src/d3d/d3d8_gl.c
+++ b/src/d3d/d3d8_gl.c
@@ -22,6 +22,7 @@
  */
 
 #include "d3d8_xbox.h"
+#include "d3d8_fvf.h"
 
 #include <SDL.h>
 #include <epoxy/gl.h>
@@ -665,7 +666,7 @@ static HRESULT __stdcall dev_GetIndices(IDirect3DDevice8 *s, IDirect3DIndexBuffe
  * this point: XYZ (or XYZRHW) + DIFFUSE + optional TEX1. */
 static void setup_fvf_attribs(DWORD fvf, UINT stride)
 {
-    GLboolean xyzrhw = (fvf & D3DFVF_XYZRHW) ? GL_TRUE : GL_FALSE;
+    GLboolean xyzrhw = d3d8_fvf_transformed(fvf) ? GL_TRUE : GL_FALSE;
     GLboolean has_diff = (fvf & D3DFVF_DIFFUSE) ? GL_TRUE : GL_FALSE;
     GLboolean has_tex  = ((fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT) > 0;
     UINT off = 0;
@@ -673,7 +674,8 @@ static void setup_fvf_attribs(DWORD fvf, UINT stride)
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, xyzrhw ? 4 : 3, GL_FLOAT, GL_FALSE, stride,
                           (const void *)(uintptr_t)off);
-    off += (xyzrhw ? 4 : 3) * sizeof(float);
+    off = d3d8_fvf_position_bytes(fvf);
+    if (fvf & D3DFVF_NORMAL) off += 12;
     /* Diffuse: D3DCOLOR (BGRA byte order, normalised to 0..1) */
     if (has_diff) {
         glEnableVertexAttribArray(1);
@@ -721,7 +723,7 @@ static void update_mvp(DWORD fvf)
     mat4_mul(&mvp, &wv, &g.m_proj);
     /* GL is column-major; D3D MATRIX is row-major. Tell GL to transpose. */
     glUniformMatrix4fv(g.u_mvp, 1, GL_TRUE, (const GLfloat *)mvp.m);
-    glUniform1i(g.u_use_xform, (fvf & D3DFVF_XYZRHW) ? 0 : 1);
+    glUniform1i(g.u_use_xform, d3d8_fvf_transformed(fvf) ? 0 : 1);
 }
 
 static HRESULT __stdcall dev_DrawPrimitiveUP(IDirect3DDevice8 *s, D3DPRIMITIVETYPE pt,

--- a/src/d3d/d3d8_shaders.c
+++ b/src/d3d/d3d8_shaders.c
@@ -17,6 +17,7 @@
  */
 
 #include "d3d8_internal.h"
+#include "d3d8_fvf.h"
 #include <d3dcompiler.h>
 #include <string.h>
 #include <stdio.h>
@@ -624,22 +625,6 @@ static UINT fvf_texcoord_size(DWORD fvf, UINT t)
     return field == 0 ? 2 : field;
 }
 
-/* Calculate vertex stride from FVF */
-static UINT fvf_stride(DWORD fvf)
-{
-    UINT stride = 0;
-    UINT tex_count = (fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
-    UINT t;
-    if (fvf & D3DFVF_XYZ)    stride += 12;
-    if (fvf & D3DFVF_XYZRHW) stride += 16;
-    if (fvf & D3DFVF_NORMAL) stride += 12;
-    if (fvf & D3DFVF_DIFFUSE) stride += 4;
-    if (fvf & D3DFVF_SPECULAR) stride += 4;
-    for (t = 0; t < tex_count; t++)
-        stride += fvf_texcoord_size(fvf, t) * 4;
-    return stride;
-}
-
 /*
  * Build input layout for a given FVF.
  *
@@ -661,16 +646,14 @@ static ID3D11InputLayout *get_or_create_layout(DWORD fvf)
     }
 
     /* POSITION */
-    if (fvf & D3DFVF_XYZRHW) {
+    if (d3d8_fvf_transformed(fvf)) {
         elems[elem_count] = (D3D11_INPUT_ELEMENT_DESC){"POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, offset, D3D11_INPUT_PER_VERTEX_DATA, 0};
-        elem_count++; offset += 16;
-    } else if (fvf & D3DFVF_XYZ) {
-        elems[elem_count] = (D3D11_INPUT_ELEMENT_DESC){"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, offset, D3D11_INPUT_PER_VERTEX_DATA, 0};
-        elem_count++; offset += 12;
+        elem_count++;
     } else {
-        elems[elem_count] = (D3D11_INPUT_ELEMENT_DESC){"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0};
+        elems[elem_count] = (D3D11_INPUT_ELEMENT_DESC){"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, offset, D3D11_INPUT_PER_VERTEX_DATA, 0};
         elem_count++;
     }
+    offset = d3d8_fvf_position_bytes(fvf);
 
     /* NORMAL */
     if (fvf & D3DFVF_NORMAL) {
@@ -943,7 +926,7 @@ void d3d8_shaders_prepare_draw(DWORD fvf)
         UINT i;
         memset(cb, 0, sizeof(*cb));
 
-        if (fvf & D3DFVF_XYZRHW) {
+        if (d3d8_fvf_transformed(fvf)) {
             float identity[16] = { 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1 };
             memcpy(cb->wvp, identity, sizeof(identity));
             memcpy(cb->world, identity, sizeof(identity));

--- a/src/d3d/d3d8_xbox.h
+++ b/src/d3d/d3d8_xbox.h
@@ -612,8 +612,14 @@ typedef enum D3DCLEAR_FLAGS {
  * Vertex declaration / FVF
  * ================================================================ */
 
+#define D3DFVF_POSITION_MASK    0x00E
 #define D3DFVF_XYZ              0x002
 #define D3DFVF_XYZRHW           0x004
+#define D3DFVF_XYZB1            0x006
+#define D3DFVF_XYZB2            0x008
+#define D3DFVF_XYZB3            0x00A
+#define D3DFVF_XYZB4            0x00C
+#define D3DFVF_XYZB5            0x00E
 #define D3DFVF_NORMAL           0x010
 #define D3DFVF_DIFFUSE          0x040
 #define D3DFVF_SPECULAR         0x080

--- a/tests/d3d8_smoke/test_main.c
+++ b/tests/d3d8_smoke/test_main.c
@@ -14,6 +14,7 @@
 #define COBJMACROS
 #include "d3d8_internal.h"
 #include "d3d8_swizzle.h"
+#include "d3d8_fvf.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -232,6 +233,26 @@ static void test_convert_linear(void)
     (void)src; (void)dst;
 }
 
+static void test_fvf_position(void)
+{
+    static const struct { DWORD position; UINT bytes; int transformed; } cases[] = {
+        {D3DFVF_XYZ, 12, 0}, {D3DFVF_XYZRHW, 16, 1},
+        {D3DFVF_XYZB1, 16, 0}, {D3DFVF_XYZB2, 20, 0},
+        {D3DFVF_XYZB3, 24, 0}, {D3DFVF_XYZB4, 28, 0},
+        {D3DFVF_XYZB5, 32, 0}, {0, 0, 0},
+    };
+    UINT i;
+    printf("test_fvf_position\n");
+    for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        DWORD fvf = cases[i].position | D3DFVF_DIFFUSE | D3DFVF_TEX1;
+        CHECK_INT("position span", d3d8_fvf_position_bytes(fvf), cases[i].bytes);
+        CHECK_INT("transformed", d3d8_fvf_transformed(fvf), cases[i].transformed);
+    }
+    /* A packed last beta still occupies one four-byte slot. */
+    CHECK_INT("indexed beta span", d3d8_fvf_position_bytes(0x1000u | D3DFVF_XYZB3), 24);
+    CHECK_INT("weighted normal offset", d3d8_fvf_position_bytes(0x118u), 20);
+}
+
 int main(void)
 {
     int i;
@@ -244,6 +265,7 @@ int main(void)
     test_swizzle_classification();
     test_unswizzle_roundtrip();
     test_convert_linear();
+    test_fvf_position();
 
     if (failures == 0) {
         printf("d3d8_smoke: ALL PASS\n");


### PR DESCRIPTION
Weighted FVF position codes were tested as independent flags. `XYZB1` (`0x006`) matched `XYZRHW` (`0x004`), selected a float4 position and disabled transformation. `XYZB2 | NORMAL | TEX1` placed the normal at byte 0 instead of 20; `XYZB3` placed it at 12 instead of 24. The following attributes were consequently read from the wrong bytes.

Decode the position field once through shared helpers used by the D3D11 and OpenGL fixed-function paths. Only XYZRHW selects pre-transformed rendering. Position storage includes the beta slots before normals/colors/texture coordinates, including packed last-beta storage. The OpenGL path also skips normal storage before locating diffuse color and UVs. Remove the unused stride helper that used the same incorrect bit tests.

This fixes input layout and transformed-position classification. It does not implement multi-matrix vertex blending or claim complete skinning support; the existing fixed-function shaders still do not consume blend weights.

Validation against upstream `a781596`:

- MSVC x64 Release build: `xbox_d3d8` and `d3d8_smoke` succeeded.
- `d3d8_smoke`: all passed, including new cases for XYZ, XYZRHW, XYZB1–5, unrelated flags and packed last-beta storage.
- `python -m pytest tools/ -q`: 200 passed, 8 subtests passed.
- `python -m tools.conformance`: 4,819 instruction vectors and 211 function vectors; zero mismatches, using 32-bit MSVC.
- Independent Astra review found no actionable correctness issues.

No game/rendering run was performed for this extraction. The OpenGL backend changes were reviewed but not compiled: the available Linux environment lacks SDL2 and libepoxy development packages.

Independent PR; no prerequisites. Proposed merge shape: squash.
