### PR TITLE
fix(audio): synchronize DirectSound playback cursors

### DIFF
--- a/src/apu/apu.h
+++ b/src/apu/apu.h
@@ -48,7 +48,7 @@ typedef struct APUMixerVoice {
     uint32_t         pcm_bytes;    /* Total buffer size in bytes */
     uint32_t         num_channels;  /* 1=mono, 2=stereo */
     uint32_t         sample_rate;   /* e.g. 22050, 44100, 48000 */
-    volatile uint32_t play_offset; /* Current byte offset into buffer */
+    uint64_t         play_offset; /* Source frame position, 16 fractional bits */
     float            volume;       /* 0.0 to 1.0 */
 } APUMixerVoice;
 
@@ -61,7 +61,13 @@ void apu_mixer_free_voice(int slot);
 /* Get pointer to a mixer voice for configuration. */
 APUMixerVoice *apu_mixer_get_voice(int slot);
 
-/* Start/stop playback on a voice. */
+/* Seek in PCM bytes (rounded down to a whole frame). Returns 0 if invalid. */
+int apu_mixer_set_position(int slot, uint32_t byte_offset);
+
+/* Snapshot playback state under the mixer lock; output pointers may be NULL. */
+void apu_mixer_get_state(int slot, uint32_t *byte_offset, int *active, int *looping);
+
+/* Start/resume or stop playback without changing the current position. */
 void apu_mixer_play(int slot, int looping);
 void apu_mixer_stop(int slot);
 

--- a/src/apu/apu_core.c
+++ b/src/apu/apu_core.c
@@ -724,7 +724,7 @@ void apu_mixer_free_voice(int slot)
 {
     if (slot < 0 || slot >= APU_MIXER_MAX_VOICES) return;
     EnterCriticalSection(&g_mixer_cs);
-    g_mixer_voices[slot].active = 0;
+    apu_mixer_stop(slot);
     g_mixer_voices[slot].pcm_data = NULL;
     g_mixer_voices[slot].pcm_bytes = 0;
     g_mixer_voices[slot].play_offset = 0;
@@ -737,25 +737,49 @@ APUMixerVoice *apu_mixer_get_voice(int slot)
     return &g_mixer_voices[slot];
 }
 
+int apu_mixer_set_position(int slot, uint32_t byte_offset)
+{
+    if (slot < 0 || slot >= APU_MIXER_MAX_VOICES) return 0;
+    EnterCriticalSection(&g_mixer_cs);
+    APUMixerVoice *v = &g_mixer_voices[slot];
+    uint32_t frame_bytes = v->num_channels * sizeof(int16_t);
+    int valid = (v->num_channels == 1 || v->num_channels == 2) &&
+                byte_offset < v->pcm_bytes &&
+                byte_offset / frame_bytes < v->pcm_bytes / frame_bytes;
+    if (valid) v->play_offset = ((uint64_t)(byte_offset / frame_bytes)) << 16;
+    LeaveCriticalSection(&g_mixer_cs);
+    return valid;
+}
+
+void apu_mixer_get_state(int slot, uint32_t *byte_offset, int *active, int *looping)
+{
+    if (byte_offset) *byte_offset = 0;
+    if (active) *active = 0;
+    if (looping) *looping = 0;
+    if (slot < 0 || slot >= APU_MIXER_MAX_VOICES) return;
+    EnterCriticalSection(&g_mixer_cs);
+    APUMixerVoice *v = &g_mixer_voices[slot];
+    if (byte_offset) *byte_offset = (uint32_t)(v->play_offset >> 16) *
+                                    v->num_channels * sizeof(int16_t);
+    if (active) *active = v->active;
+    if (looping) *looping = v->active && v->looping;
+    LeaveCriticalSection(&g_mixer_cs);
+}
+
 void apu_mixer_play(int slot, int looping)
 {
     if (g_audio_muted) return;
     if (slot < 0 || slot >= APU_MIXER_MAX_VOICES) return;
+    EnterCriticalSection(&g_mixer_cs);
     APUMixerVoice *v = &g_mixer_voices[slot];
-    if (!v->pcm_data || v->pcm_bytes == 0) return;
-    v->looping = looping;
-    v->play_offset = 0;
-    v->active = 1;
-    InterlockedIncrement((volatile LONG *)&g_mixer_active_count);
-
-    /* Wake up APU thread if it was paused */
-    extern MCPXAPUState *g_state;
-    if (g_state) {
-        qemu_mutex_lock(&g_state->lock);
-        g_state->pause_requested = false;
-        qemu_cond_signal(&g_state->cond);
-        qemu_mutex_unlock(&g_state->lock);
+    if (!v->pcm_data || (v->num_channels != 1 && v->num_channels != 2) ||
+        v->pcm_bytes < v->num_channels * sizeof(int16_t)) {
+        LeaveCriticalSection(&g_mixer_cs);
+        return;
     }
+    v->looping = looping;
+    if (!v->active) InterlockedIncrement((volatile LONG *)&g_mixer_active_count);
+    v->active = 1;
 
     static int play_log_count = 0;
     if (play_log_count < 20) {
@@ -763,22 +787,35 @@ void apu_mixer_play(int slot, int looping)
                 slot, v->pcm_bytes, v->num_channels, v->sample_rate, v->volume, looping);
         play_log_count++;
     }
+    LeaveCriticalSection(&g_mixer_cs);
+
+    /* The frame thread takes the APU lock before the mixer lock. */
+    extern MCPXAPUState *g_state;
+    if (g_state) {
+        qemu_mutex_lock(&g_state->lock);
+        g_state->pause_requested = false;
+        qemu_cond_signal(&g_state->cond);
+        qemu_mutex_unlock(&g_state->lock);
+    }
 }
 
 void apu_mixer_stop(int slot)
 {
     if (slot < 0 || slot >= APU_MIXER_MAX_VOICES) return;
+    EnterCriticalSection(&g_mixer_cs);
     if (g_mixer_voices[slot].active) {
         g_mixer_voices[slot].active = 0;
         InterlockedDecrement((volatile LONG *)&g_mixer_active_count);
     }
+    LeaveCriticalSection(&g_mixer_cs);
 }
 
 /* Mix all active voices into frame_buf. Called from mcpx_apu_monitor_frame.
- * play_offset is stored as a 16.16 fixed-point source frame position. */
+ * Keep 16 fractional bits in a wide offset so buffers can exceed 65536 frames. */
 static void mixer_render(int16_t frame_buf[][2], int num_samples)
 {
     if (!g_mixer_initialized) return;
+    EnterCriticalSection(&g_mixer_cs);
 
     for (int v = 0; v < APU_MIXER_MAX_VOICES; v++) {
         APUMixerVoice *voice = &g_mixer_voices[v];
@@ -790,8 +827,9 @@ static void mixer_render(int16_t frame_buf[][2], int num_samples)
         if (total_frames == 0) continue;
 
         /* Fixed-point 16.16 increment per output sample */
-        uint32_t inc = (uint32_t)(((uint64_t)voice->sample_rate << 16) / 48000);
-        uint32_t pos = voice->play_offset; /* 16.16 fixed-point */
+        uint64_t inc = ((uint64_t)voice->sample_rate << 16) / 48000;
+        uint64_t pos = voice->play_offset;
+        uint64_t end = (uint64_t)total_frames << 16;
         float vol = voice->volume;
 
         for (int i = 0; i < num_samples; i++) {
@@ -799,9 +837,10 @@ static void mixer_render(int16_t frame_buf[][2], int num_samples)
 
             if (src_frame >= total_frames) {
                 if (voice->looping) {
-                    pos = 0;
-                    src_frame = 0;
+                    pos %= end;
+                    src_frame = (uint32_t)(pos >> 16);
                 } else {
+                    pos = 0;
                     voice->active = 0;
                     InterlockedDecrement((volatile LONG *)&g_mixer_active_count);
                     break;
@@ -833,11 +872,13 @@ static void mixer_render(int16_t frame_buf[][2], int num_samples)
         uint32_t end_frame = pos >> 16;
         if (end_frame >= total_frames) {
             if (voice->looping) {
-                voice->play_offset = 0;
+                voice->play_offset = pos % end;
             } else if (voice->active) {
+                voice->play_offset = 0;
                 voice->active = 0;
                 InterlockedDecrement((volatile LONG *)&g_mixer_active_count);
             }
         }
     }
+    LeaveCriticalSection(&g_mixer_cs);
 }

--- a/src/audio/dsound_device.c
+++ b/src/audio/dsound_device.c
@@ -31,8 +31,6 @@ typedef struct DSoundBuffer {
     LONG    ref_count;
     void   *buffer_data;
     DWORD   buffer_size;
-    DWORD   play_cursor;
-    DWORD   status;  /* DSBSTATUS_* flags */
     LONG    volume;  /* hundredths of dB */
     DWORD   frequency;
     WORD    channels;     /* 1=mono, 2=stereo */
@@ -74,6 +72,7 @@ static ULONG __stdcall buf_Release(IDirectSoundBuffer8 *self)
 static HRESULT __stdcall buf_SetBufferData(IDirectSoundBuffer8 *self, const void *pvBufferData, DWORD dwBufferBytes)
 {
     DSoundBuffer *buf = buf_from_iface(self);
+    apu_mixer_stop(buf->mixer_slot);
     free(buf->buffer_data);
     buf->buffer_data = NULL;
     buf->buffer_size = dwBufferBytes;
@@ -84,11 +83,12 @@ static HRESULT __stdcall buf_SetBufferData(IDirectSoundBuffer8 *self, const void
     }
 
     /* Update mixer voice with new buffer data */
-    if (buf->mixer_slot >= 0 && buf->buffer_data && buf->bits_per_sample == 16) {
+    if (buf->mixer_slot >= 0 && buf->bits_per_sample == 16) {
         APUMixerVoice *v = apu_mixer_get_voice(buf->mixer_slot);
         if (v) {
             v->pcm_data = (const int16_t *)buf->buffer_data;
-            v->pcm_bytes = dwBufferBytes;
+            v->pcm_bytes = buf->buffer_data ? dwBufferBytes : 0;
+            v->play_offset = 0;
             v->num_channels = buf->channels;
             v->sample_rate = buf->frequency;
         }
@@ -136,21 +136,26 @@ static HRESULT __stdcall buf_Unlock(IDirectSoundBuffer8 *self, void *p1, DWORD n
 
 static HRESULT __stdcall buf_SetCurrentPosition(IDirectSoundBuffer8 *self, DWORD dwNewPosition)
 {
-    buf_from_iface(self)->play_cursor = dwNewPosition;
-    return S_OK;
+    return apu_mixer_set_position(buf_from_iface(self)->mixer_slot, dwNewPosition)
+        ? S_OK : E_INVALIDARG;
 }
 
 static HRESULT __stdcall buf_GetCurrentPosition(IDirectSoundBuffer8 *self, DWORD *pdwPlay, DWORD *pdwWrite)
 {
     DSoundBuffer *buf = buf_from_iface(self);
-    if (pdwPlay)  *pdwPlay = buf->play_cursor;
-    if (pdwWrite) *pdwWrite = buf->play_cursor;
+    uint32_t cursor;
+    apu_mixer_get_state(buf->mixer_slot, &cursor, NULL, NULL);
+    if (pdwPlay)  *pdwPlay = cursor;
+    if (pdwWrite) *pdwWrite = cursor;
     return S_OK;
 }
 
 static HRESULT __stdcall buf_GetStatus(IDirectSoundBuffer8 *self, DWORD *pdwStatus)
 {
-    if (pdwStatus) *pdwStatus = buf_from_iface(self)->status;
+    int active, looping;
+    apu_mixer_get_state(buf_from_iface(self)->mixer_slot, NULL, &active, &looping);
+    if (pdwStatus) *pdwStatus = (active ? DSBSTATUS_PLAYING : 0) |
+                                (looping ? DSBSTATUS_LOOPING : 0);
     return S_OK;
 }
 
@@ -158,8 +163,6 @@ static HRESULT __stdcall buf_Play(IDirectSoundBuffer8 *self, DWORD r1, DWORD r2,
 {
     (void)r1; (void)r2;
     DSoundBuffer *buf = buf_from_iface(self);
-    buf->status = DSBSTATUS_PLAYING;
-    if (dwFlags & DSBPLAY_LOOPING) buf->status |= DSBSTATUS_LOOPING;
 
     /* Start playback through APU mixer */
     if (buf->mixer_slot >= 0) {
@@ -171,7 +174,6 @@ static HRESULT __stdcall buf_Play(IDirectSoundBuffer8 *self, DWORD r1, DWORD r2,
 static HRESULT __stdcall buf_Stop(IDirectSoundBuffer8 *self)
 {
     DSoundBuffer *buf = buf_from_iface(self);
-    buf->status = 0;
     if (buf->mixer_slot >= 0) {
         apu_mixer_stop(buf->mixer_slot);
     }

--- a/tests/audio_mixer/run.py
+++ b/tests/audio_mixer/run.py
@@ -1,0 +1,38 @@
+"""Compile the actual mixer and DirectSound buffer code, without audio hardware.
+
+The APU core also contains the hardware emulation and host output backend.
+Take its mixer declarations and implementation verbatim; only the APU wakeup
+target is stubbed (NULL). Requires GCC on PATH, including MinGW on Windows.
+"""
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+root = pathlib.Path(__file__).resolve().parents[2]
+core = (root / "src/apu/apu_core.c").read_text(encoding="utf-8")
+declarations = core[core.index("static void mixer_init(void);"):
+                    core.index("struct McpxApuDebug g_dbg;")]
+implementation = core[core.index("static void mixer_init(void)\n{"):]
+source = """
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include "platform/xbox_winnt.h"
+#include "apu/apu.h"
+struct MCPXAPUState { int lock, cond; bool pause_requested; };
+MCPXAPUState *g_state = NULL;
+int g_audio_muted = 0;
+static void qemu_mutex_lock(int *p) { (void)p; }
+static void qemu_mutex_unlock(int *p) { (void)p; }
+static void qemu_cond_signal(int *p) { (void)p; }
+""" + declarations + implementation
+source += (root / "tests/audio_mixer/test_main.c").read_text(encoding="utf-8")
+with tempfile.TemporaryDirectory(prefix="audio-mixer-") as directory:
+    exe = str(pathlib.Path(directory) / "test.exe")
+    command = ["gcc", "-std=c11", "-Isrc", "-x", "c", "-",
+               "src/audio/dsound_device.c", "-o", exe]
+    if sys.platform != "win32":
+        command += ["src/platform/win32_compat.c", "-lm", "-lpthread"]
+    subprocess.run(command, cwd=root, input=source, text=True, check=True)
+    subprocess.run([exe], check=True, timeout=10)

--- a/tests/audio_mixer/test_main.c
+++ b/tests/audio_mixer/test_main.c
@@ -1,0 +1,141 @@
+/* Run with: python tests/audio_mixer/run.py */
+#include <assert.h>
+#include "audio/dsound_xbox.h"
+
+static IDirectSoundBuffer8 *make_buffer(WORD channels, DWORD rate,
+                                      const int16_t *pcm, DWORD bytes)
+{
+    IDirectSound8 *ds;
+    IDirectSoundBuffer8 *buf;
+    XBOX_WAVEFORMATEX format = {0};
+    format.nChannels = channels;
+    format.nSamplesPerSec = rate;
+    format.wBitsPerSample = 16;
+    DSBUFFERDESC desc = {0};
+    desc.lpwfxFormat = &format;
+    assert(xbox_DirectSoundCreate(NULL, &ds, NULL) == S_OK);
+    assert(ds->lpVtbl->CreateSoundBuffer(ds, &desc, &buf, NULL) == S_OK);
+    assert(buf->lpVtbl->SetBufferData(buf, pcm, bytes) == S_OK);
+    return buf;
+}
+
+static void check_state(IDirectSoundBuffer8 *buf, DWORD cursor, DWORD status)
+{
+    DWORD play = ~0u, write = ~0u, actual_status = ~0u;
+    assert(buf->lpVtbl->GetCurrentPosition(buf, &play, &write) == S_OK);
+    assert(play == cursor && write == cursor);
+    assert(buf->lpVtbl->GetStatus(buf, &actual_status) == S_OK);
+    assert(actual_status == status);
+}
+
+static void check_sample(int16_t expected)
+{
+    int16_t out[1][2] = {{0}};
+    mixer_render(out, 1);
+    assert(out[0][0] == expected && out[0][1] == expected);
+}
+
+static void check_playback(WORD channels)
+{
+    int16_t pcm[8];
+    for (int i = 0; i < 4 * channels; i++) pcm[i] = (i / channels + 1) * 100;
+    DWORD frame_bytes = channels * sizeof(int16_t);
+    IDirectSoundBuffer8 *buf = make_buffer(channels, 48000, pcm, 4 * frame_bytes);
+    check_state(buf, 0, 0);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, 2 * frame_bytes) == S_OK);
+    check_state(buf, 2 * frame_bytes, 0);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_sample(300);
+    check_state(buf, 3 * frame_bytes, DSBSTATUS_PLAYING);
+
+    /* Play on a playing buffer must neither rewind nor double-count it. */
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    assert(g_mixer_active_count == 1);
+    assert(buf->lpVtbl->Stop(buf) == S_OK);
+    assert(buf->lpVtbl->Stop(buf) == S_OK);
+    check_sample(0);
+    check_state(buf, 3 * frame_bytes, 0);
+    assert(g_mixer_active_count == 0);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_sample(400);
+    check_state(buf, 0, 0);
+    assert(g_mixer_active_count == 0);
+    check_sample(0);
+
+    assert(buf->lpVtbl->Play(buf, 0, 0, DSBPLAY_LOOPING) == S_OK);
+    check_sample(100);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, 3 * frame_bytes + 1) == S_OK);
+    check_sample(400);
+    check_state(buf, 0, DSBSTATUS_PLAYING | DSBSTATUS_LOOPING);
+    check_sample(100);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, 4 * frame_bytes) == E_INVALIDARG);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, UINT32_MAX) == E_INVALIDARG);
+    check_state(buf, frame_bytes, DSBSTATUS_PLAYING | DSBSTATUS_LOOPING);
+
+    /* Updating Play flags takes effect without restarting. */
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    int16_t out[5][2] = {{0}};
+    mixer_render(out, 5);
+    assert(out[0][0] == 200 && out[1][0] == 300 && out[2][0] == 400);
+    assert(out[3][0] == 0 && out[4][0] == 0);
+    check_state(buf, 0, 0);
+    assert(g_mixer_active_count == 0);
+    buf->lpVtbl->GetCurrentPosition(buf, NULL, NULL);
+    buf->lpVtbl->GetStatus(buf, NULL);
+    buf->lpVtbl->Release(buf);
+}
+
+int main(void)
+{
+    check_playback(1);
+    check_playback(2);
+
+    /* Fractional source frames survive a loop and a Stop/Play boundary. */
+    const int16_t pcm[] = {100, 200, 300, 400};
+    IDirectSoundBuffer8 *buf = make_buffer(1, 72000, pcm, sizeof(pcm));
+    assert(buf->lpVtbl->Play(buf, 0, 0, DSBPLAY_LOOPING) == S_OK);
+    check_sample(100);
+    check_sample(200);
+    check_sample(400);
+    check_state(buf, 0, DSBSTATUS_PLAYING | DSBSTATUS_LOOPING);
+    assert(buf->lpVtbl->Stop(buf) == S_OK);
+    assert(buf->lpVtbl->Play(buf, 0, 0, DSBPLAY_LOOPING) == S_OK);
+    check_sample(100);
+    check_state(buf, 4, DSBSTATUS_PLAYING | DSBSTATUS_LOOPING);
+    /* Replacing storage starts a new buffer; clearing it cannot replay freed PCM. */
+    assert(buf->lpVtbl->SetBufferData(buf, pcm, 2 * sizeof(int16_t)) == S_OK);
+    check_state(buf, 0, 0);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_sample(100);
+    assert(buf->lpVtbl->SetBufferData(buf, NULL, 0) == S_OK);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_state(buf, 0, 0);
+    check_sample(0);
+    buf->lpVtbl->Release(buf);
+
+    /* Crossing the old 16.16 limit must not jump back to the first frame. */
+    int16_t *long_pcm = calloc(65538, sizeof(int16_t));
+    assert(long_pcm);
+    long_pcm[65535] = 123;
+    long_pcm[65536] = 456;
+    long_pcm[65537] = 789;
+    buf = make_buffer(1, 48000, long_pcm, 65538 * sizeof(int16_t));
+    free(long_pcm);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, 65535 * sizeof(int16_t)) == S_OK);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_sample(123);
+    check_state(buf, 65536 * sizeof(int16_t), DSBSTATUS_PLAYING);
+    check_sample(456);
+    check_sample(789);
+    check_state(buf, 0, 0);
+    buf->lpVtbl->Release(buf);
+
+    buf = make_buffer(1, 48000, NULL, 0);
+    assert(buf->lpVtbl->Play(buf, 0, 0, 0) == S_OK);
+    check_state(buf, 0, 0);
+    assert(buf->lpVtbl->SetCurrentPosition(buf, 0) == E_INVALIDARG);
+    buf->lpVtbl->Release(buf);
+    assert(g_mixer_active_count == 0);
+    puts("audio mixer regression: passed");
+    return 0;
+}


### PR DESCRIPTION
## Problem

DirectSound buffers kept a separate `play_cursor` and `status`, while the software mixer advanced its own position and stopped independently. `SetCurrentPosition` therefore did not seek playback, `Play` discarded the requested position, and getters remained stale after rendering or completion.

An offline reproduction using the real DirectSound methods and mixer showed:

```text
seek_then_play first_sample=100 expected=300 mixer_frame=1 reported_byte_cursor=8 expected_cursor=12
after_completion mixer_active=0 reported_status=1 expected_status=0
```

The buffer contains four distinguishable stereo frames at 48 kHz. Seeking to byte 8 should play frame 2, then report byte 12 after one rendered frame. The original regression failed at the expected-sample assertion; it passes with this change.

## Changes

- Read cursor and playing/looping status from a locked mixer snapshot; translate byte seeks to source-frame positions under the same lock as rendering.
- Preserve position across Play/Stop, update loop flags without restarting, and avoid double-counting repeated Play calls. Natural completion clears playing state and returns the cursor to zero.
- Widen the fixed-point source position to retain 16 fractional bits beyond 65,535 frames; preserve fractional overshoot when looping.
- Stop and reset the mixer voice when replacing buffer storage, including clearing its PCM pointer for an empty buffer.
- Add a deterministic offline regression covering mono/stereo seek before and during playback, resume, completion at and within a render batch, repeated Play/Stop, loop flags, fractional wrap, invalid seeks, replacement/clearing, and crossing the former position limit.

The test compiles the mixer declarations/implementation verbatim from `apu_core.c` with the actual `dsound_device.c`. It does not duplicate the mixer algorithm. The APU wakeup target is NULL; no audio device or game files are required. Run with Python and GCC/MinGW on PATH:

```text
python tests/audio_mixer/run.py
```

## Validation

- Offline audio regression: passed (Windows GCC).
- MSVC 19.44, VS 2022 x64 Release: `xbox_dsound` and `xbox_apu` built successfully. Existing unrelated `getenv` declaration warning in `apu_mmio_hook.c` remains.
- `python -m pytest tools/ -q`: 200 passed, 8 subtests passed.
- `python -m tools.conformance`: 4,819 instruction vectors and 211 function vectors, zero mismatches.
- Independent correctness review and `git diff --check`: passed.

No game playback, audio hardware/listening test, or Xbox oracle run was performed. This fixes a reproduced library defect, not a claim that a particular game reaches this implementation. The write cursor still approximates the play cursor; existing raw voice configuration/allocation races and unsupported audio formats are outside this change. The regression is synchronous and is not a concurrency stress test.

## Merge shape

Independent PR against `main` at `a781596e2181f8d4b15336659897ce07bdd7d56a`; no dependency on the FVF or XOR PRs. Proposed squash merge. No generated game code or private assets are included.
