### PR TITLE
fix(compat): Add Slim reader/writer locks, GetFileSizeEx

### DIFF
--- a/src/kernel/kernel_file.c
+++ b/src/kernel/kernel_file.c
@@ -38,6 +38,20 @@ static const char* get_xbox_path(PXBOX_OBJECT_ATTRIBUTES ObjectAttributes)
     return ObjectAttributes->ObjectName->Buffer;
 }
 
+/* Xbox volume geometry.
+ *
+ * FATX uses 16 KB clusters: 512-byte sectors, 32 sectors per cluster. That is
+ * not cosmetic. A title's CRT startup asks for FileFsSizeInformation and
+ * multiplies SectorsPerAllocationUnit by BytesPerSector, then *requires* the
+ * product to equal the cluster size it was built for. Half-Life 2 checks for
+ * 0x4000 and returns STATUS_DEVICE_NOT_READY (0xC000014F) otherwise, which
+ * aborts CRT init before main ever runs -- the process then exits cleanly,
+ * which reads as a title that did nothing rather than one that failed.
+ *
+ * Reporting the host's PC-typical 4 KB cluster (512 x 8) fails that check. */
+#define XBOX_BYTES_PER_SECTOR       512u
+#define XBOX_SECTORS_PER_CLUSTER    32u      /* 512 * 32 = 16384 */
+
 /* ======================================================================== */
 #if defined(_WIN32)
 /* ====================  Win32 backend  =================================== */
@@ -469,20 +483,6 @@ NTSTATUS __stdcall xbox_NtSetInformationFile(
             return STATUS_NOT_IMPLEMENTED;
     }
 }
-
-/* Xbox volume geometry.
- *
- * FATX uses 16 KB clusters: 512-byte sectors, 32 sectors per cluster. That is
- * not cosmetic. A title's CRT startup asks for FileFsSizeInformation and
- * multiplies SectorsPerAllocationUnit by BytesPerSector, then *requires* the
- * product to equal the cluster size it was built for. Half-Life 2 checks for
- * 0x4000 and returns STATUS_DEVICE_NOT_READY (0xC000014F) otherwise, which
- * aborts CRT init before main ever runs -- the process then exits cleanly,
- * which reads as a title that did nothing rather than one that failed.
- *
- * Reporting the host's PC-typical 4 KB cluster (512 x 8) fails that check. */
-#define XBOX_BYTES_PER_SECTOR       512u
-#define XBOX_SECTORS_PER_CLUSTER    32u      /* 512 * 32 = 16384 */
 
 NTSTATUS __stdcall xbox_NtQueryVolumeInformationFile(
     HANDLE FileHandle, PXBOX_IO_STATUS_BLOCK IoStatusBlock,

--- a/src/kernel/nv2a_pb_scan.c
+++ b/src/kernel/nv2a_pb_scan.c
@@ -22,6 +22,7 @@
  */
 #include <stdio.h>
 #include <stdint.h>
+#include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/kernel/xbox_memory_layout.c
+++ b/src/kernel/xbox_memory_layout.c
@@ -15,8 +15,12 @@
 #include "xbox_memory_layout.h"
 #include "kernel.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
+#if !defined(_WIN32)
+#include <unistd.h>   /* _exit */
+#endif
 
 /* XBE header field offsets (per xboxdevwiki.net/Xbe) */
 #define XBE_MAGIC_OFFSET        0x0000

--- a/src/platform/win32_compat.c
+++ b/src/platform/win32_compat.c
@@ -120,6 +120,71 @@ VOID DeleteCriticalSection(LPCRITICAL_SECTION cs)
 }
 
 /* ===================================================================== */
+/* Slim reader/writer locks                                              */
+/* ===================================================================== */
+
+/* An SRWLOCK is usable straight from SRWLOCK_INIT, so the pthread_rwlock_t
+ * behind it has to appear on first use. Unlike the condition variables below
+ * -- whose lazy init is covered by the caller holding the paired CRITICAL
+ * SECTION -- an SRWLOCK is by definition taken from several threads at once
+ * with nothing else held, so first use genuinely races. Serialise just that:
+ * once Ptr is published, every acquire is a plain atomic load. */
+static pthread_rwlock_t *srw_lazy_init(PSRWLOCK lock)
+{
+    pthread_rwlock_t *rw = __atomic_load_n((pthread_rwlock_t **)&lock->Ptr,
+                                           __ATOMIC_ACQUIRE);
+    if (!rw) {
+        static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
+        pthread_mutex_lock(&init_lock);
+        rw = (pthread_rwlock_t *)lock->Ptr;
+        if (!rw) {
+            rw = (pthread_rwlock_t *)malloc(sizeof(*rw));
+            pthread_rwlock_init(rw, NULL);
+            __atomic_store_n((pthread_rwlock_t **)&lock->Ptr, rw, __ATOMIC_RELEASE);
+        }
+        pthread_mutex_unlock(&init_lock);
+    }
+    return rw;
+}
+
+VOID InitializeSRWLock(PSRWLOCK lock)
+{
+    lock->Ptr = NULL;
+    srw_lazy_init(lock);
+}
+
+VOID AcquireSRWLockShared(PSRWLOCK lock)     { pthread_rwlock_rdlock(srw_lazy_init(lock)); }
+VOID ReleaseSRWLockShared(PSRWLOCK lock)     { pthread_rwlock_unlock(srw_lazy_init(lock)); }
+VOID AcquireSRWLockExclusive(PSRWLOCK lock)  { pthread_rwlock_wrlock(srw_lazy_init(lock)); }
+VOID ReleaseSRWLockExclusive(PSRWLOCK lock)  { pthread_rwlock_unlock(srw_lazy_init(lock)); }
+
+/* ===================================================================== */
+/* One-time initialisation                                               */
+/* ===================================================================== */
+
+/* Win32 semantics: the callback runs at most once for a given INIT_ONCE, and
+ * a callback returning FALSE leaves it un-run so a later call retries. Ptr
+ * doubles as the "done" flag. One global mutex covers every INIT_ONCE --
+ * initialisation is rare, and the fast path never touches it. */
+BOOL InitOnceExecuteOnce(PINIT_ONCE once, PINIT_ONCE_FN fn, PVOID param, PVOID *context)
+{
+    static pthread_mutex_t once_lock = PTHREAD_MUTEX_INITIALIZER;
+
+    if (__atomic_load_n(&once->Ptr, __ATOMIC_ACQUIRE))
+        return TRUE;
+
+    pthread_mutex_lock(&once_lock);
+    BOOL ok = TRUE;
+    if (!once->Ptr) {
+        ok = fn(once, param, context);
+        if (ok)
+            __atomic_store_n(&once->Ptr, (PVOID)1, __ATOMIC_RELEASE);
+    }
+    pthread_mutex_unlock(&once_lock);
+    return ok;
+}
+
+/* ===================================================================== */
 /* Condition variables (paired with a CRITICAL_SECTION)                  */
 /* ===================================================================== */
 
@@ -1137,6 +1202,16 @@ DWORD GetFileSize(HANDLE h, LPDWORD high)
     if (fstat(fd, &st) != 0) return INVALID_FILE_SIZE;
     if (high) *high = (DWORD)(((uint64_t)st.st_size >> 32) & 0xFFFFFFFFu);
     return (DWORD)(st.st_size & 0xFFFFFFFFu);
+}
+
+BOOL GetFileSizeEx(HANDLE h, PLARGE_INTEGER size)
+{
+    int fd = w32_handle_fd(h);
+    if (fd < 0 || !size) { SetLastError(ERROR_INVALID_HANDLE); return FALSE; }
+    struct stat st;
+    if (fstat(fd, &st) != 0) { SetLastError(ERROR_GEN_FAILURE); return FALSE; }
+    size->QuadPart = (LONGLONG)st.st_size;
+    return TRUE;
 }
 
 BOOL FlushFileBuffers(HANDLE h)

--- a/src/platform/win32_compat.h
+++ b/src/platform/win32_compat.h
@@ -29,6 +29,7 @@ extern "C" {
 #define WAIT_IO_COMPLETION   0x000000C0u
 #define WAIT_TIMEOUT         0x00000102u
 #define WAIT_FAILED          0xFFFFFFFFu
+#define MAXIMUM_WAIT_OBJECTS 64
 #ifndef INFINITE
 #define INFINITE             0xFFFFFFFFu
 #endif
@@ -75,6 +76,7 @@ typedef VOID  (WINAPI *WAITORTIMERCALLBACK)(PVOID lpParameter, BOOLEAN TimerOrWa
 typedef void  *LPSECURITY_ATTRIBUTES;
 typedef void  *PTP_CALLBACK_INSTANCE;
 typedef VOID  (WINAPI *PTP_SIMPLE_CALLBACK)(PTP_CALLBACK_INSTANCE Instance, PVOID Context);
+typedef BOOL  (WINAPI *PINIT_ONCE_FN)(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context);
 
 /* ---- Last-error -------------------------------------------------------- */
 DWORD GetLastError(void);
@@ -95,6 +97,16 @@ VOID EnterCriticalSection(LPCRITICAL_SECTION cs);
 VOID LeaveCriticalSection(LPCRITICAL_SECTION cs);
 BOOL TryEnterCriticalSection(LPCRITICAL_SECTION cs);
 VOID DeleteCriticalSection(LPCRITICAL_SECTION cs);
+
+/* ---- Slim reader/writer locks ------------------------------------------ */
+VOID InitializeSRWLock(PSRWLOCK lock);
+VOID AcquireSRWLockShared(PSRWLOCK lock);
+VOID ReleaseSRWLockShared(PSRWLOCK lock);
+VOID AcquireSRWLockExclusive(PSRWLOCK lock);
+VOID ReleaseSRWLockExclusive(PSRWLOCK lock);
+
+/* ---- One-time initialisation ------------------------------------------- */
+BOOL InitOnceExecuteOnce(PINIT_ONCE once, PINIT_ONCE_FN fn, PVOID param, PVOID *context);
 
 /* ---- Condition variables (paired with a CRITICAL_SECTION) ----------- */
 VOID InitializeConditionVariable(PCONDITION_VARIABLE cv);
@@ -238,6 +250,7 @@ HANDLE CreateFileW(LPCWSTR name, DWORD access, DWORD share,
 BOOL   ReadFile(HANDLE h, LPVOID buf, DWORD len, LPDWORD nread, void *overlapped);
 BOOL   WriteFile(HANDLE h, LPCVOID buf, DWORD len, LPDWORD nwritten, void *overlapped);
 DWORD  GetFileSize(HANDLE h, LPDWORD high);
+BOOL   GetFileSizeEx(HANDLE h, PLARGE_INTEGER size);
 BOOL   FlushFileBuffers(HANDLE h);
 
 /* ---- Keyboard + window helpers (stubs on POSIX) --------------------- */
@@ -479,6 +492,11 @@ void  _aligned_free(void *ptr);
 /* ---- Case-insensitive string compare --------------------------------- */
 int _stricmp(const char *a, const char *b);
 int _strnicmp(const char *a, const char *b, SIZE_T n);
+
+/* ---- MSVC CRT "safe" variants ---------------------------------------- */
+/* strtok_s takes the same (str, delim, context) arguments as POSIX strtok_r
+ * and returns the same thing, so the name is all that differs. */
+#define strtok_s strtok_r
 
 /* ---- Wide-string helpers (operate on the 16-bit Xbox WCHAR) ----------
  * Named xbox_wcs* (not macros over wcs*) so they never collide with the

--- a/src/platform/xbox_winnt.h
+++ b/src/platform/xbox_winnt.h
@@ -210,6 +210,15 @@ typedef struct _RTL_CRITICAL_SECTION {
 typedef struct { PVOID Ptr; } CONDITION_VARIABLE, *PCONDITION_VARIABLE;
 #define CONDITION_VARIABLE_INIT { NULL }
 
+/* SRWLOCK / INIT_ONCE: same single-pointer layout as Win32, and like it both
+ * are usable from a static initialiser with no explicit Initialize* call.
+ * Ptr is a pthread_rwlock_t* on POSIX. */
+typedef struct { PVOID Ptr; } SRWLOCK, *PSRWLOCK;
+#define SRWLOCK_INIT { NULL }
+
+typedef struct { PVOID Ptr; } INIT_ONCE, *PINIT_ONCE, *LPINIT_ONCE;
+#define INIT_ONCE_STATIC_INIT { NULL }
+
 /* ---- Common small structs ---------------------------------------------- */
 typedef struct _FILETIME   { DWORD dwLowDateTime; DWORD dwHighDateTime; }
         FILETIME, *PFILETIME, *LPFILETIME;

--- a/src/video/fb_present.c
+++ b/src/video/fb_present.c
@@ -14,12 +14,13 @@
  *
  * Off unless RECOMP_FB_WINDOW is set.
  */
+#include <stdint.h>
+
 #if defined(_WIN32)
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
 
 extern ptrdiff_t xbox_GetMemoryOffset(void);
 


### PR DESCRIPTION
Posix build is broken due to recent changes.

* Add missing includes `ISO C99 and later do not support implicit function declarations`
* Posix equivalent of `strtok_s` is `strtok_r`
* Implement `GetFileSizeEx` similar to `GetFileSize` with INVALID_HANDLE
* Implement Add Slim reader/writer locks using <pthread.h>

The FATX geometry constants in kernel_file.c were defined inside the _WIN32 half but referenced from the POSIX half's NtQueryVolumeInformationFile. I hoisted them above the backend split rather than duplicating. Not sure if this would lead to a bug  (Half-Life 2 aborts CRT init if it isn't 0x4000 comment)

219 passed, 1 skipped in 2.11s
