### PR TITLE
fix(d3d8): invalidate cached state for all depth and stencil changes

### DIFF
--- a/src/d3d/d3d8_states.c
+++ b/src/d3d/d3d8_states.c
@@ -23,10 +23,10 @@ static ID3D11DepthStencilState *g_ds_state = NULL;
 static ID3D11RasterizerState   *g_raster_state = NULL;
 static ID3D11SamplerState      *g_sampler_states[4] = { NULL, NULL, NULL, NULL };
 
-/* Last known render state hash for dirty detection */
+/* Last known render state identity for dirty detection */
 static DWORD g_last_blend_hash = 0;
-static DWORD g_last_ds_hash = 0;
 static DWORD g_last_raster_hash = 0;
+static D3D11_DEPTH_STENCIL_DESC g_last_ds_desc;
 
 /* ================================================================
  * D3D8 → D3D11 enum translation
@@ -102,17 +102,6 @@ static DWORD hash_blend_states(const DWORD *rs)
            (rs[D3DRS_COLORWRITEENABLE] << 16);
 }
 
-static DWORD hash_ds_states(const DWORD *rs)
-{
-    return rs[D3DRS_ZENABLE] ^
-           (rs[D3DRS_ZWRITEENABLE] << 2) ^
-           (rs[D3DRS_ZFUNC] << 4) ^
-           (rs[D3DRS_STENCILENABLE] << 8) ^
-           (rs[D3DRS_STENCILFUNC] << 10) ^
-           (rs[D3DRS_STENCILREF] << 14) ^
-           (rs[D3DRS_STENCILMASK] << 18);
-}
-
 static DWORD hash_raster_states(const DWORD *rs)
 {
     return rs[D3DRS_CULLMODE] ^
@@ -154,17 +143,8 @@ static void update_blend_state(const DWORD *rs)
 
 static void update_depth_stencil_state(const DWORD *rs)
 {
-    DWORD hash = hash_ds_states(rs);
     D3D11_DEPTH_STENCIL_DESC dsd;
     HRESULT hr;
-
-    if (hash == g_last_ds_hash && g_ds_state) return;
-    g_last_ds_hash = hash;
-
-    if (g_ds_state) {
-        ID3D11DepthStencilState_Release(g_ds_state);
-        g_ds_state = NULL;
-    }
 
     memset(&dsd, 0, sizeof(dsd));
     dsd.DepthEnable = rs[D3DRS_ZENABLE] ? TRUE : FALSE;
@@ -181,9 +161,19 @@ static void update_depth_stencil_state(const DWORD *rs)
     dsd.FrontFace.StencilPassOp = d3d8_to_d3d11_stencilop(rs[D3DRS_STENCILPASS]);
     dsd.BackFace = dsd.FrontFace;
 
+    /* Zeroed padding makes the complete descriptor comparable; the reference
+     * is bound separately. */
+    if (g_ds_state && memcmp(&dsd, &g_last_ds_desc, sizeof(dsd)) == 0) return;
+    if (g_ds_state) {
+        ID3D11DepthStencilState_Release(g_ds_state);
+        g_ds_state = NULL;
+    }
+
     hr = ID3D11Device_CreateDepthStencilState(d3d8_GetD3D11Device(), &dsd, &g_ds_state);
     if (FAILED(hr))
         fprintf(stderr, "D3D8: CreateDepthStencilState failed: 0x%08lX\n", hr);
+    else
+        memcpy(&g_last_ds_desc, &dsd, sizeof(dsd));
 }
 
 static void update_rasterizer_state(const DWORD *rs)
@@ -322,7 +312,6 @@ void d3d8_states_shutdown(void)
         }
     }
     g_last_blend_hash = 0;
-    g_last_ds_hash = 0;
     g_last_raster_hash = 0;
 }
 

--- a/tests/d3d8_smoke/CMakeLists.txt
+++ b/tests/d3d8_smoke/CMakeLists.txt
@@ -15,4 +15,12 @@ if(WIN32)
     if(MSVC)
         target_compile_options(d3d8_smoke PRIVATE /W3)
     endif()
+
+    # Exercise bound state objects on D3D11's software device (no window/GPU).
+    add_executable(d3d8_states_smoke
+        test_states.c
+        ../../src/d3d/d3d8_states.c
+    )
+    target_include_directories(d3d8_states_smoke PRIVATE ../../src/d3d)
+    target_link_libraries(d3d8_states_smoke PRIVATE platform d3d11)
 endif()

--- a/tests/d3d8_smoke/test_states.c
+++ b/tests/d3d8_smoke/test_states.c
@@ -1,0 +1,120 @@
+/* Verify the real state cache through D3D11 WARP, without a window or game. */
+#include "d3d8_internal.h"
+#include <stdio.h>
+#include <string.h>
+
+static ID3D11Device *device;
+static ID3D11DeviceContext *context;
+static DWORD rs[256];
+static int failures;
+
+ID3D11Device *d3d8_GetD3D11Device(void) { return device; }
+ID3D11DeviceContext *d3d8_GetD3D11Context(void) { return context; }
+const DWORD *d3d8_GetRenderStates(void) { return rs; }
+const DWORD *d3d8_GetTSS(DWORD stage) { (void)stage; return NULL; }
+
+#define CHECK(name, cond) \
+    do { if (!(cond)) { printf("FAIL: %s\n", name); failures++; } } while (0)
+
+static D3D11_DEPTH_STENCIL_DESC apply(void)
+{
+    D3D11_DEPTH_STENCIL_DESC desc;
+    ID3D11DepthStencilState *state = NULL;
+    UINT ref = 0;
+    memset(&desc, 0, sizeof(desc));
+    d3d8_states_apply();
+    ID3D11DeviceContext_OMGetDepthStencilState(context, &state, &ref);
+    CHECK("depth/stencil state bound", state != NULL);
+    CHECK("stencil reference bound", ref == rs[D3DRS_STENCILREF]);
+    if (state) {
+        ID3D11DepthStencilState_GetDesc(state, &desc);
+        ID3D11DepthStencilState_Release(state);
+    }
+    return desc;
+}
+
+int main(void)
+{
+    D3D11_DEPTH_STENCIL_DESC desc;
+    HRESULT hr = D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_WARP, NULL, 0,
+        NULL, 0, D3D11_SDK_VERSION, &device, NULL, &context);
+    if (FAILED(hr)) {
+        fprintf(stderr, "D3D11CreateDevice(WARP) failed: 0x%08lX\n", hr);
+        return 1;
+    }
+
+    rs[D3DRS_ZENABLE] = TRUE;
+    rs[D3DRS_ZWRITEENABLE] = TRUE;
+    rs[D3DRS_ZFUNC] = D3DCMP_LESSEQUAL;
+    rs[D3DRS_STENCILENABLE] = TRUE;
+    rs[D3DRS_STENCILFUNC] = D3DCMP_ALWAYS;
+    rs[D3DRS_STENCILMASK] = 0xFF;
+    rs[D3DRS_STENCILWRITEMASK] = 0xFF;
+    rs[D3DRS_STENCILFAIL] = 1;
+    rs[D3DRS_STENCILZFAIL] = 1;
+    rs[D3DRS_STENCILPASS] = 1;
+    rs[D3DRS_SRCBLEND] = D3DBLEND_ONE;
+    rs[D3DRS_DESTBLEND] = D3DBLEND_ZERO;
+    rs[D3DRS_COLORWRITEENABLE] = 0xF;
+    rs[D3DRS_CULLMODE] = D3DCULL_NONE;
+    rs[D3DRS_FILLMODE] = D3DFILL_SOLID;
+    d3d8_states_init();
+    desc = apply();
+    CHECK("initial write mask", desc.StencilWriteMask == 0xFF);
+
+    rs[D3DRS_STENCILWRITEMASK] = 0x5A;
+    desc = apply();
+    CHECK("STENCILWRITEMASK", desc.StencilWriteMask == 0x5A);
+    rs[D3DRS_STENCILFAIL] = 2;
+    desc = apply();
+    CHECK("STENCILFAIL", desc.FrontFace.StencilFailOp == D3D11_STENCIL_OP_ZERO &&
+        desc.BackFace.StencilFailOp == D3D11_STENCIL_OP_ZERO);
+    rs[D3DRS_STENCILZFAIL] = 3;
+    desc = apply();
+    CHECK("STENCILZFAIL", desc.FrontFace.StencilDepthFailOp == D3D11_STENCIL_OP_REPLACE &&
+        desc.BackFace.StencilDepthFailOp == D3D11_STENCIL_OP_REPLACE);
+    rs[D3DRS_STENCILPASS] = 6;
+    desc = apply();
+    CHECK("STENCILPASS", desc.FrontFace.StencilPassOp == D3D11_STENCIL_OP_INVERT &&
+        desc.BackFace.StencilPassOp == D3D11_STENCIL_OP_INVERT);
+
+    /* These changes cancel in the old hash: (16 << 14) == (1 << 18). */
+    rs[D3DRS_STENCILREF] = 16;
+    rs[D3DRS_STENCILMASK] = 0xFE;
+    desc = apply();
+    CHECK("reference/read-mask hash collision", desc.StencilReadMask == 0xFE);
+    rs[D3DRS_STENCILREF] = 17;
+    desc = apply();
+    CHECK("reference-only update preserves descriptor", desc.StencilReadMask == 0xFE);
+
+    rs[D3DRS_ZWRITEENABLE] = FALSE;
+    desc = apply();
+    CHECK("ZWRITEENABLE", desc.DepthWriteMask == D3D11_DEPTH_WRITE_MASK_ZERO);
+    rs[D3DRS_ZFUNC] = D3DCMP_GREATER;
+    desc = apply();
+    CHECK("ZFUNC", desc.DepthFunc == D3D11_COMPARISON_GREATER);
+    rs[D3DRS_ZENABLE] = FALSE;
+    desc = apply();
+    CHECK("ZENABLE", desc.DepthEnable == FALSE);
+    rs[D3DRS_STENCILFUNC] = D3DCMP_EQUAL;
+    desc = apply();
+    CHECK("STENCILFUNC", desc.FrontFace.StencilFunc == D3D11_COMPARISON_EQUAL &&
+        desc.BackFace.StencilFunc == D3D11_COMPARISON_EQUAL);
+    rs[D3DRS_STENCILENABLE] = FALSE;
+    desc = apply();
+    CHECK("STENCILENABLE", desc.StencilEnable == FALSE);
+    rs[D3DRS_STENCILENABLE] = TRUE;
+    desc = apply();
+
+    d3d8_states_shutdown();
+    ID3D11DeviceContext_ClearState(context);
+    d3d8_states_init();
+    desc = apply();
+    CHECK("cache recreates after shutdown", desc.StencilWriteMask == 0x5A);
+    d3d8_states_shutdown();
+    ID3D11DeviceContext_ClearState(context);
+    ID3D11DeviceContext_Release(context);
+    ID3D11Device_Release(device);
+    printf("d3d8_states_smoke: %d FAILURE(S)\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

The depth/stencil cache key omits `STENCILWRITEMASK`, `STENCILFAIL`, `STENCILZFAIL`, and `STENCILPASS`. Changing only one of these states can reuse a stale D3D11 state object. The XOR hash can also collide: changing stencil reference from 0 to 16 while changing the read mask from 0xFF to 0xFE cancels out in the old key.

## Change

- Compare the complete, zero-initialized `D3D11_DEPTH_STENCIL_DESC` instead of a partial hash.
- Keep stencil reference separate: it is passed to `OMSetDepthStencilState`, not stored in the descriptor.
- Update the cached descriptor only after successful creation. A missing state object still triggers a retry.
- Add a windowless D3D11 WARP regression test that inspects the actual bound descriptor and stencil reference.

This intentionally leaves the blend and rasterizer caches unchanged.

## Validation

Refreshed and tested against upstream `bc528f1d15d3bc681bee3d50ad1d1c88f307d394` on Windows with MSVC x64, Release:

```powershell
cmake -S . -B build -G "Visual Studio 17 2022" -A x64
cmake --build build --config Release --target xbox_d3d8 d3d8_states_smoke d3d8_smoke
./build/src/d3d/d3d8_smoke/Release/d3d8_states_smoke.exe
./build/src/d3d/d3d8_smoke/Release/d3d8_smoke.exe
```

- Library build passed.
- State regression: 0 failures. Covers each formerly omitted state, the hash collision, reference-only updates, depth settings, and shutdown/reinitialization.
- Existing format/swizzle smoke test: all pass.
- During initial reproduction, the state regression reported 5 failures before the fix.
- `git diff --check origin/main...HEAD` passed.

No game assets or generated game code are included. WARP verifies bound state, not a full game rendering sequence.

## Merge

Independent PR targeting `main`; no prerequisite PRs. Proposed merge method: squash.
