### PR TITLE
fix(d3d8): preserve white RGB for A8 textures across shader paths

### DIFF
--- a/src/d3d/d3d8_combiners.c
+++ b/src/d3d/d3d8_combiners.c
@@ -515,6 +515,7 @@ int d3d8_combiners_generate_hlsl(const NV2ACombinerState *state,
     EMIT("    uint   alpha_func;\n");
     EMIT("    uint   alpha_test_enable;\n");
     EMIT("    uint   fog_enable;\n");
+    EMIT("    uint4  alpha_only;\n");
     EMIT("};\n\n");
 
     /* ---- Input structure ---- */
@@ -559,6 +560,9 @@ int d3d8_combiners_generate_hlsl(const NV2ACombinerState *state,
             EMIT("    float4 r_t%d = tex%d.Sample(samp%d, input.tc%d.xy);\n",
                  i, i, i, i);
         }
+        /* Preserve disabled stages and sampled alpha. */
+        if (state->tex_mode[i] != NV2A_TEXMODE_NONE)
+            EMIT("    if (alpha_only[%d]) r_t%d.rgb = 1.0;\n", i, i);
     }
 
     /* Temporary registers: R0 initialized to T0 (NV2A convention),
@@ -1045,6 +1049,10 @@ BOOL d3d8_combiners_prepare_draw(void)
         cb->alpha_func = rs[D3DRS_ALPHAFUNC];
         cb->alpha_test_enable = rs[D3DRS_ALPHATESTENABLE] ? 1 : 0;
         cb->fog_enable = rs[D3DRS_FOGENABLE] ? 1 : 0;
+        for (i = 0; i < NV2A_MAX_TEXTURES; i++) {
+            D3DFORMAT format = d3d8_base_format(d3d8_GetStageTexture(i));
+            cb->alpha_only[i] = format == D3DFMT_A8 || format == D3DFMT_LIN_A8;
+        }
 
         ID3D11DeviceContext_Unmap(ctx, (ID3D11Resource *)g_combiner_cb, 0);
     }

--- a/src/d3d/d3d8_combiners.h
+++ b/src/d3d/d3d8_combiners.h
@@ -248,6 +248,7 @@ typedef struct NV2APSConstants {
     UINT  alpha_func;                       /* D3DCMPFUNC enum value */
     UINT  alpha_test_enable;                /* 0 or 1 */
     UINT  fog_enable;                       /* 0 or 1 */
+    UINT  alpha_only[NV2A_MAX_TEXTURES];     /* A8 sampling uses white RGB */
 } NV2APSConstants;
 
 /* ================================================================

--- a/src/d3d/d3d8_device.c
+++ b/src/d3d/d3d8_device.c
@@ -823,9 +823,7 @@ static HRESULT __stdcall dev_DrawPrimitive(IDirect3DDevice8 *self, D3DPRIMITIVET
     if (vertex_count == 0) return E_INVALIDARG;
 
     /* Prepare pipeline: shaders, input layout, constant buffers, render states */
-    /* Vertex shader: try programmable VS first, fall back to FVF fixed-function */
-    if (!d3d8_vsh_prepare_draw(g_device_state.vertex_shader))
-        d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
+    d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
     d3d8_combiners_prepare_draw(); /* overrides PS if combiner shader is active */
     d3d8_states_apply();
 
@@ -845,8 +843,7 @@ static HRESULT __stdcall dev_DrawIndexedPrimitive(IDirect3DDevice8 *self, D3DPRI
     if (index_count == 0) return E_INVALIDARG;
 
     /* Vertex shader: try programmable VS first, fall back to FVF fixed-function */
-    if (!d3d8_vsh_prepare_draw(g_device_state.vertex_shader))
-        d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
+    d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
     d3d8_combiners_prepare_draw(); /* overrides PS if combiner shader is active */
     d3d8_states_apply();
 
@@ -890,8 +887,7 @@ static HRESULT __stdcall dev_DrawPrimitiveUP(IDirect3DDevice8 *self, D3DPRIMITIV
         0, 1, &g_up_ring_buffer, &VertexStreamZeroStride, &ring_offset);
 
     /* Vertex shader: try programmable VS first, fall back to FVF fixed-function */
-    if (!d3d8_vsh_prepare_draw(g_device_state.vertex_shader))
-        d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
+    d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
     d3d8_combiners_prepare_draw(); /* overrides PS if combiner shader is active */
     d3d8_states_apply();
 
@@ -955,8 +951,7 @@ static HRESULT __stdcall dev_DrawIndexedPrimitiveUP(IDirect3DDevice8 *self, D3DP
         tmp_ib, ib_fmt, 0);
 
     /* Vertex shader: try programmable VS first, fall back to FVF fixed-function */
-    if (!d3d8_vsh_prepare_draw(g_device_state.vertex_shader))
-        d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
+    d3d8_shaders_prepare_draw(g_device_state.vertex_shader);
     d3d8_combiners_prepare_draw(); /* overrides PS if combiner shader is active */
     d3d8_states_apply();
 

--- a/src/d3d/d3d8_internal.h
+++ b/src/d3d/d3d8_internal.h
@@ -246,8 +246,7 @@ HRESULT d3d8_CreateImageSurfaceImpl(UINT Width, UINT Height, D3DFORMAT Format,
  * as D3D8Texture. */
 ID3D11ShaderResourceView *d3d8_base_srv(IDirect3DBaseTexture8 *texture);
 
-/* Read the D3DFORMAT / palette stage of any base texture via the shared
- * D3D8Texture layout overlay. */
+/* Read the D3DFORMAT of any base texture. */
 D3DFORMAT d3d8_base_format(IDirect3DBaseTexture8 *texture);
 void      d3d8_base_set_palette(IDirect3DBaseTexture8 *texture, UINT palette);
 

--- a/src/d3d/d3d8_internal.h
+++ b/src/d3d/d3d8_internal.h
@@ -281,8 +281,8 @@ HRESULT d3d8_CreateTextureImpl(UINT Width, UINT Height, UINT Levels, DWORD Usage
 HRESULT d3d8_shaders_init(void);
 void    d3d8_shaders_shutdown(void);
 
-/* Bind shaders + input layout for the given FVF, upload transform CBs */
-void    d3d8_shaders_prepare_draw(DWORD fvf);
+/* Select programmable/FVF vertex state and refresh fixed-function pixel state. */
+void    d3d8_shaders_prepare_draw(DWORD handle);
 
 /* ================================================================
  * NV2A Register Combiner pixel shaders (d3d8_combiners.c)

--- a/src/d3d/d3d8_resources.c
+++ b/src/d3d/d3d8_resources.c
@@ -1646,10 +1646,12 @@ static UINT base_texture_palette(IDirect3DBaseTexture8 *texture)
     return *(UINT *)((BYTE *)texture + offsetof(D3D8Texture, palette));
 }
 
-/* Read the D3DFORMAT of any base texture via the D3D8Texture overlay. */
+/* Volume textures place depth before the format, unlike 2D/cube textures. */
 D3DFORMAT d3d8_base_format(IDirect3DBaseTexture8 *texture)
 {
     if (!texture) return D3DFMT_UNKNOWN;
+    if (IDirect3DBaseTexture8_GetType(texture) == D3DRTYPE_VOLUMETEXTURE)
+        return ((D3D8VolumeTexture *)texture)->d3d8_format;
     return *(D3DFORMAT *)((BYTE *)texture + offsetof(D3D8Texture, d3d8_format));
 }
 

--- a/src/d3d/d3d8_shaders.c
+++ b/src/d3d/d3d8_shaders.c
@@ -272,6 +272,7 @@ static const char g_ps_body[] =
     "    uint4  StageColor[4];\n"
     "    // Per-stage: x=alphaarg1, y=alphaarg2, z=0, w=0\n"
     "    uint4  StageAlpha[4];\n"
+    "    uint4  AlphaOnly;\n"
     "};\n"
     "\n"
     "struct PS_IN {\n"
@@ -453,6 +454,9 @@ static void build_ps_source(UINT sig, char *buf, int bufsize)
         off += snprintf(buf + off, bufsize - off,
                         "    texels[%d] = tex%d.Sample(samp%d, input.tex%d.%s);\n",
                         i, i, i, i, dim ? "xyz" : "xy");
+        /* Xbox A8 samples white RGB; DXGI A8 supplies zero RGB. */
+        off += snprintf(buf + off, bufsize - off,
+                        "    if (AlphaOnly[%d]) texels[%d].rgb = 1.0;\n", i, i);
     }
     off += snprintf(buf + off, bufsize - off, "%s", g_ps_tail);
 }
@@ -601,6 +605,7 @@ typedef struct {
     UINT  _pad0;
     UINT  stage_color[4][4];     /* [stage][x=colorop, y=arg1, z=arg2, w=alphaop] */
     UINT  stage_alpha[4][4];     /* [stage][x=alphaarg1, y=alphaarg2, z=0, w=0] */
+    UINT  alpha_only[4];
 } PSConstants;
 
 /* ================================================================
@@ -1139,7 +1144,9 @@ void d3d8_shaders_prepare_draw(DWORD fvf)
 
         /* Per-stage texture state */
         for (stage = 0; stage < 4; stage++) {
+            D3DFORMAT format = d3d8_base_format(d3d8_GetStageTexture(stage));
             const DWORD *tss = d3d8_GetTSS(stage);
+            pc->alpha_only[stage] = format == D3DFMT_A8 || format == D3DFMT_LIN_A8;
             if (!tss) {
                 pc->stage_color[stage][0] = D3DTOP_DISABLE;
                 continue;

--- a/src/d3d/d3d8_shaders.c
+++ b/src/d3d/d3d8_shaders.c
@@ -894,11 +894,10 @@ void d3d8_shaders_shutdown(void)
  * Pre-draw binding
  * ================================================================ */
 
-void d3d8_shaders_prepare_draw(DWORD fvf)
+static void ff_vs_prepare_draw(DWORD fvf)
 {
     ID3D11DeviceContext *ctx = d3d8_GetD3D11Context();
     ID3D11InputLayout *layout;
-    ID3D11PixelShader *ps;
     D3D11_MAPPED_SUBRESOURCE mapped;
     const D3DMATRIX *world, *view, *proj;
     const DWORD *rs;
@@ -910,14 +909,7 @@ void d3d8_shaders_prepare_draw(DWORD fvf)
     rs = d3d8_GetRenderStates();
     tex_count = (fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
 
-    /* Bind the fixed-function pixel shader matching the texture types
-     * currently bound to each stage (2D/cube/volume). */
-    ps = ff_ps_get_shader(ff_ps_compute_signature());
-    if (!ps) return;
-
-    /* Bind shaders */
     ID3D11DeviceContext_VSSetShader(ctx, g_vs, NULL, 0);
-    ID3D11DeviceContext_PSSetShader(ctx, ps, NULL, 0);
 
     /* Bind input layout */
     layout = get_or_create_layout(fvf);
@@ -1090,6 +1082,31 @@ void d3d8_shaders_prepare_draw(DWORD fvf)
         ID3D11DeviceContext_Unmap(ctx, (ID3D11Resource *)g_vs_light_cb, 0);
     }
 
+    {
+        ID3D11Buffer *vs_cbs[2] = { g_vs_cb, g_vs_light_cb };
+        ID3D11DeviceContext_VSSetConstantBuffers(ctx, 0, 2, vs_cbs);
+    }
+}
+
+void d3d8_shaders_prepare_draw(DWORD handle)
+{
+    ID3D11DeviceContext *ctx = d3d8_GetD3D11Context();
+    ID3D11PixelShader *ps;
+    D3D11_MAPPED_SUBRESOURCE mapped;
+    const DWORD *rs;
+    HRESULT hr;
+
+    if (!ctx) return;
+    if (!d3d8_vsh_prepare_draw(handle))
+        ff_vs_prepare_draw(handle);
+
+    /* Pixel state is independent of whether the vertex shader is programmable. */
+    if (!g_ps_cb) return;
+    ps = ff_ps_get_shader(ff_ps_compute_signature());
+    if (!ps) return;
+    ID3D11DeviceContext_PSSetShader(ctx, ps, NULL, 0);
+    rs = d3d8_GetRenderStates();
+
     /* ---- PS Constant Buffer ---- */
     hr = ID3D11DeviceContext_Map(ctx, (ID3D11Resource *)g_ps_cb, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
     if (SUCCEEDED(hr)) {
@@ -1168,10 +1185,5 @@ void d3d8_shaders_prepare_draw(DWORD fvf)
         ID3D11DeviceContext_Unmap(ctx, (ID3D11Resource *)g_ps_cb, 0);
     }
 
-    /* Bind constant buffers */
-    {
-        ID3D11Buffer *vs_cbs[2] = { g_vs_cb, g_vs_light_cb };
-        ID3D11DeviceContext_VSSetConstantBuffers(ctx, 0, 2, vs_cbs);
-    }
     ID3D11DeviceContext_PSSetConstantBuffers(ctx, 0, 1, &g_ps_cb);
 }

--- a/tests/d3d8_smoke/CMakeLists.txt
+++ b/tests/d3d8_smoke/CMakeLists.txt
@@ -15,4 +15,13 @@ if(WIN32)
     if(MSVC)
         target_compile_options(d3d8_smoke PRIVATE /W3)
     endif()
+
+    add_executable(d3d8_a8
+        test_a8.c
+        ../../src/d3d/d3d8_resources.c
+        ../../src/d3d/d3d8_shaders.c
+        ../../src/d3d/d3d8_combiners.c
+    )
+    target_include_directories(d3d8_a8 PRIVATE ../../src/d3d)
+    target_link_libraries(d3d8_a8 PRIVATE platform d3d11 dxgi dxguid d3dcompiler)
 endif()

--- a/tests/d3d8_smoke/test_a8.c
+++ b/tests/d3d8_smoke/test_a8.c
@@ -8,6 +8,8 @@
 
 static ID3D11Device *device;
 static ID3D11DeviceContext *context;
+static ID3D11VertexShader *vs;
+static ID3D11Buffer *programmable_constants;
 static IDirect3DBaseTexture8 *textures[4];
 static DWORD states[512], stages[4][64];
 static const D3DMATRIX identity = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
@@ -28,6 +30,17 @@ BOOL d3d8_GetLightEnable(DWORD index) { (void)index; return FALSE; }
 const D3DMATERIAL8 *d3d8_GetMaterial(void) { return NULL; }
 UINT d3d8_GetNumLights(void) { return 0; }
 
+/* Model successful programmable-VS preparation without Xbox microcode.
+ * Bind real D3D11 vertex state so pixel preparation must preserve it. */
+BOOL d3d8_vsh_prepare_draw(DWORD handle)
+{
+    if (handle != 0x10000) return FALSE;
+    ID3D11DeviceContext_VSSetShader(context, vs, NULL, 0);
+    ID3D11DeviceContext_IASetInputLayout(context, NULL);
+    ID3D11DeviceContext_VSSetConstantBuffers(context, 1, 1, &programmable_constants);
+    return TRUE;
+}
+
 #define REQUIRE(call) do { HRESULT hr = (call); if (FAILED(hr)) { \
     fprintf(stderr, "%s: HRESULT 0x%08lx\n", #call, (unsigned long)hr); exit(1); } } while (0)
 
@@ -44,13 +57,13 @@ int main(void)
     static const BYTE alphas[] = {0, 1, 127, 255};
     ID3D11Texture2D *target, *readback;
     ID3D11RenderTargetView *rtv;
-    ID3D11VertexShader *vs;
     ID3D11SamplerState *sampler;
     ID3D11RasterizerState *rasterizer;
     ID3DBlob *blob;
     D3D11_TEXTURE2D_DESC td = {0};
     D3D11_SAMPLER_DESC sd = {0};
     D3D11_RASTERIZER_DESC rd = {0};
+    D3D11_BUFFER_DESC cbd = {0};
     D3D11_VIEWPORT viewport = {0, 0, 1, 1, 0, 1};
     unsigned f, a, stage, path, c, kind;
     int failures = 0;
@@ -64,6 +77,9 @@ int main(void)
     REQUIRE(ID3D11Device_CreateVertexShader(device, ID3D10Blob_GetBufferPointer(blob),
         ID3D10Blob_GetBufferSize(blob), NULL, &vs));
     ID3D10Blob_Release(blob);
+    cbd.ByteWidth = 16;
+    cbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    REQUIRE(ID3D11Device_CreateBuffer(device, &cbd, NULL, &programmable_constants));
     td.Width = td.Height = td.MipLevels = td.ArraySize = td.SampleDesc.Count = 1;
     td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     td.BindFlags = D3D11_BIND_RENDER_TARGET;
@@ -141,12 +157,36 @@ int main(void)
                     else if (kind == 2) REQUIRE(volume->lpVtbl->UnlockBox(volume, 1));
                     else REQUIRE(flat->lpVtbl->UnlockRect(flat, 1));
                 }
-                for (path = 0; path < 2; path++) {
+                for (path = 0; path < (kind == 0 ? 3u : 2u); path++) {
                     D3D11_MAPPED_SUBRESOURCE mapped;
-                    d3d8_shaders_prepare_draw(D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1);
-                    if (path && !d3d8_combiners_prepare_draw()) return 1;
-                    ID3D11DeviceContext_VSSetShader(context, vs, NULL, 0);
-                    ID3D11DeviceContext_IASetInputLayout(context, NULL);
+                    if (path == 2) {
+                        D3D8Texture previous = *(D3D8Texture *)tex;
+                        ID3D11VertexShader *bound_vs;
+                        ID3D11Buffer *bound_cb;
+                        ID3D11InputLayout *bound_layout;
+                        /* Seed an FFP draw with the opposite format, then
+                         * switch texture and vertex shader before the draw. */
+                        previous.d3d8_format = f == 2 ? D3DFMT_A8 : D3DFMT_LIN_A8R8G8B8;
+                        textures[stage] = (IDirect3DBaseTexture8 *)&previous;
+                        d3d8_shaders_prepare_draw(D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1);
+                        textures[stage] = tex;
+                        d3d8_shaders_prepare_draw(0x10000);
+                        ID3D11DeviceContext_VSGetShader(context, &bound_vs, NULL, NULL);
+                        ID3D11DeviceContext_VSGetConstantBuffers(context, 1, 1, &bound_cb);
+                        ID3D11DeviceContext_IAGetInputLayout(context, &bound_layout);
+                        if (bound_vs != vs || bound_cb != programmable_constants || bound_layout) {
+                            fprintf(stderr, "FAIL programmable vertex state overwritten\n");
+                            failures++;
+                        }
+                        if (bound_vs) ID3D11VertexShader_Release(bound_vs);
+                        if (bound_cb) ID3D11Buffer_Release(bound_cb);
+                        if (bound_layout) ID3D11InputLayout_Release(bound_layout);
+                    } else {
+                        d3d8_shaders_prepare_draw(D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1);
+                        if (path && !d3d8_combiners_prepare_draw()) return 1;
+                        ID3D11DeviceContext_VSSetShader(context, vs, NULL, 0);
+                        ID3D11DeviceContext_IASetInputLayout(context, NULL);
+                    }
                     ID3D11DeviceContext_IASetPrimitiveTopology(context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
                     ID3D11DeviceContext_Draw(context, 3, 0);
                     ID3D11DeviceContext_CopyResource(context, (ID3D11Resource *)readback, (ID3D11Resource *)target);
@@ -154,7 +194,7 @@ int main(void)
                     if (memcmp(mapped.pData, expected, 4)) {
                         BYTE *got = mapped.pData;
                         fprintf(stderr, "FAIL kind=%u stage=%u format=0x%x alpha=%u path=%s: RGBA=%u,%u,%u,%u\n",
-                            kind, stage, formats[f], alphas[a], path ? "combiner" : "fixed",
+                            kind, stage, formats[f], alphas[a], path == 2 ? "programmable-VS" : path ? "combiner" : "fixed",
                             got[0], got[1], got[2], got[3]);
                         failures++;
                     }
@@ -173,11 +213,12 @@ int main(void)
     ID3D11RasterizerState_Release(rasterizer);
     ID3D11SamplerState_Release(sampler);
     ID3D11VertexShader_Release(vs);
+    ID3D11Buffer_Release(programmable_constants);
     ID3D11RenderTargetView_Release(rtv);
     ID3D11Texture2D_Release(target);
     ID3D11Texture2D_Release(readback);
     ID3D11DeviceContext_Release(context);
     ID3D11Device_Release(device);
-    printf("d3d8_a8: %d failures (288 draws)\n", failures);
+    printf("d3d8_a8: %d failures (336 draws)\n", failures);
     return failures != 0;
 }

--- a/tests/d3d8_smoke/test_a8.c
+++ b/tests/d3d8_smoke/test_a8.c
@@ -1,0 +1,183 @@
+/* Sample A8 through both real pixel-shader paths on the D3D11 WARP device.
+ * No game data, window, or hardware adapter is needed. */
+#include "d3d8_internal.h"
+#include <d3dcompiler.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static ID3D11Device *device;
+static ID3D11DeviceContext *context;
+static IDirect3DBaseTexture8 *textures[4];
+static DWORD states[512], stages[4][64];
+static const D3DMATRIX identity = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+
+ID3D11Device *d3d8_GetD3D11Device(void) { return device; }
+ID3D11DeviceContext *d3d8_GetD3D11Context(void) { return context; }
+ID3D11RenderTargetView *d3d8_GetDefaultRTV(void) { return NULL; }
+IDirect3DDevice8 *xbox_GetD3DDevice(void) { return NULL; }
+const DWORD *d3d8_GetPalette(DWORD stage) { (void)stage; return states; }
+const DWORD *d3d8_GetRenderStates(void) { return states; }
+const DWORD *d3d8_GetTSS(DWORD stage) { return stages[stage]; }
+IDirect3DBaseTexture8 *d3d8_GetStageTexture(DWORD stage) { return textures[stage]; }
+UINT d3d8_GetBackbufferWidth(void) { return 1; }
+UINT d3d8_GetBackbufferHeight(void) { return 1; }
+const D3DMATRIX *d3d8_GetTransform(D3DTRANSFORMSTATETYPE type) { (void)type; return &identity; }
+const D3DLIGHT8 *d3d8_GetLight(DWORD index) { (void)index; return NULL; }
+BOOL d3d8_GetLightEnable(DWORD index) { (void)index; return FALSE; }
+const D3DMATERIAL8 *d3d8_GetMaterial(void) { return NULL; }
+UINT d3d8_GetNumLights(void) { return 0; }
+
+#define REQUIRE(call) do { HRESULT hr = (call); if (FAILED(hr)) { \
+    fprintf(stderr, "%s: HRESULT 0x%08lx\n", #call, (unsigned long)hr); exit(1); } } while (0)
+
+int main(void)
+{
+    static const char vs_source[] =
+        "struct V { float4 p:SV_POSITION; float4 c:COLOR0; float4 s:COLOR1;"
+        " float3 t0:TEXCOORD0; float3 t1:TEXCOORD1; float3 t2:TEXCOORD2;"
+        " float3 t3:TEXCOORD3; float f:TEXCOORD4; float4 v:TEXCOORD5; };"
+        "V main(uint id:SV_VertexID) { V o=(V)0;"
+        " o.p=float4(id==2?3:-1,id==1?3:-1,0,1);"
+        " o.c=1; o.t0=o.t1=o.t2=o.t3=float3(0.5,0.5,0.5); return o; }";
+    static const D3DFORMAT formats[] = {D3DFMT_A8, D3DFMT_LIN_A8, D3DFMT_LIN_A8R8G8B8};
+    static const BYTE alphas[] = {0, 1, 127, 255};
+    ID3D11Texture2D *target, *readback;
+    ID3D11RenderTargetView *rtv;
+    ID3D11VertexShader *vs;
+    ID3D11SamplerState *sampler;
+    ID3D11RasterizerState *rasterizer;
+    ID3DBlob *blob;
+    D3D11_TEXTURE2D_DESC td = {0};
+    D3D11_SAMPLER_DESC sd = {0};
+    D3D11_RASTERIZER_DESC rd = {0};
+    D3D11_VIEWPORT viewport = {0, 0, 1, 1, 0, 1};
+    unsigned f, a, stage, path, c, kind;
+    int failures = 0;
+
+    REQUIRE(D3D11CreateDevice(NULL, D3D_DRIVER_TYPE_WARP, NULL, 0, NULL, 0,
+        D3D11_SDK_VERSION, &device, NULL, &context));
+    REQUIRE(d3d8_shaders_init());
+    REQUIRE(d3d8_combiners_init());
+    REQUIRE(D3DCompile(vs_source, sizeof(vs_source), NULL, NULL, NULL, "main",
+        "vs_4_0", 0, 0, &blob, NULL));
+    REQUIRE(ID3D11Device_CreateVertexShader(device, ID3D10Blob_GetBufferPointer(blob),
+        ID3D10Blob_GetBufferSize(blob), NULL, &vs));
+    ID3D10Blob_Release(blob);
+    td.Width = td.Height = td.MipLevels = td.ArraySize = td.SampleDesc.Count = 1;
+    td.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    td.BindFlags = D3D11_BIND_RENDER_TARGET;
+    REQUIRE(ID3D11Device_CreateTexture2D(device, &td, NULL, &target));
+    REQUIRE(ID3D11Device_CreateRenderTargetView(device, (ID3D11Resource *)target, NULL, &rtv));
+    td.BindFlags = 0;
+    td.Usage = D3D11_USAGE_STAGING;
+    td.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+    REQUIRE(ID3D11Device_CreateTexture2D(device, &td, NULL, &readback));
+    sd.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+    sd.AddressU = sd.AddressV = sd.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sd.MinLOD = 1;  /* Exercise the last mip of each 2x2 (or 2x2x2) texture. */
+    sd.MaxLOD = D3D11_FLOAT32_MAX;
+    REQUIRE(ID3D11Device_CreateSamplerState(device, &sd, &sampler));
+    rd.FillMode = D3D11_FILL_SOLID;
+    rd.CullMode = D3D11_CULL_NONE;
+    REQUIRE(ID3D11Device_CreateRasterizerState(device, &rd, &rasterizer));
+    ID3D11DeviceContext_RSSetState(context, rasterizer);
+    ID3D11DeviceContext_RSSetViewports(context, 1, &viewport);
+    ID3D11DeviceContext_OMSetRenderTargets(context, 1, &rtv, NULL);
+
+    for (kind = 0; kind < 3; kind++)
+    for (stage = 0; stage < 4; stage++) {
+        for (c = 0; c < 4; c++) {
+            stages[c][D3DTSS_COLOROP] = D3DTOP_SELECTARG1;
+            stages[c][D3DTSS_ALPHAOP] = D3DTOP_SELECTARG1;
+            stages[c][D3DTSS_COLORARG1] = c == stage ? D3DTA_TEXTURE : D3DTA_CURRENT;
+            stages[c][D3DTSS_ALPHAARG1] = c == stage ? D3DTA_TEXTURE : D3DTA_CURRENT;
+        }
+        /* Final combiner: D.rgb and G.a select the sampled texture. */
+        states[D3DRS_PSFINALCOMBINERINPUTSABCD] = (NV2A_REG_T0 + stage) << 24;
+        states[D3DRS_PSFINALCOMBINERINPUTSEFG] = (NV2A_REG_T0 + stage) << 16;
+        d3d8_combiners_mark_dirty();
+        UINT mode = kind == 1 ? NV2A_TEXMODE_CUBEMAP : kind == 2 ? NV2A_TEXMODE_3D : NV2A_TEXMODE_2D;
+        d3d8_combiners_set_pixel_shader(1u | (mode << (8 + 4 * stage)));
+        for (f = 0; f < sizeof(formats) / sizeof(formats[0]); f++) {
+            IDirect3DBaseTexture8 *tex;
+            ID3D11ShaderResourceView *srv;
+            if (kind == 1) {
+                REQUIRE(d3d8_CreateCubeTextureImpl(2, 2, 0, formats[f], (IDirect3DCubeTexture8 **)&tex));
+            } else if (kind == 2) {
+                REQUIRE(d3d8_CreateVolumeTextureImpl(2, 2, 2, 2, 0, formats[f], (IDirect3DVolumeTexture8 **)&tex));
+            } else {
+                REQUIRE(d3d8_CreateTextureImpl(2, 2, 2, 0, formats[f], (IDirect3DTexture8 **)&tex));
+            }
+            textures[stage] = tex;
+            srv = d3d8_base_srv(textures[stage]);
+            ID3D11DeviceContext_PSSetShaderResources(context, stage, 1, &srv);
+            ID3D11DeviceContext_PSSetSamplers(context, stage, 1, &sampler);
+            for (a = 0; a < sizeof(alphas); a++) {
+                BYTE pixel[4] = {31, 63, 95, alphas[a]};
+                BYTE expected[4] = {255, 255, 255, alphas[a]};
+                UINT face;
+                if (f == 2) {
+                    expected[0] = 95; expected[1] = 63; expected[2] = 31;
+                } else {
+                    pixel[0] = alphas[a];
+                }
+                for (face = 0; face < (kind == 1 ? 6u : 1u); face++) {
+                    D3DLOCKED_RECT lock;
+                    D3DLOCKED_BOX box;
+                    IDirect3DCubeTexture8 *cube = (IDirect3DCubeTexture8 *)tex;
+                    IDirect3DVolumeTexture8 *volume = (IDirect3DVolumeTexture8 *)tex;
+                    IDirect3DTexture8 *flat = (IDirect3DTexture8 *)tex;
+                    if (kind == 1) {
+                        REQUIRE(cube->lpVtbl->LockRect(cube, face, 1, &lock, NULL, 0));
+                    } else if (kind == 2) {
+                        REQUIRE(volume->lpVtbl->LockBox(volume, 1, &box, NULL, 0));
+                        lock.pBits = box.pBits;
+                    } else {
+                        REQUIRE(flat->lpVtbl->LockRect(flat, 1, &lock, NULL, 0));
+                    }
+                    memcpy(lock.pBits, pixel, f == 2 ? 4 : 1);
+                    if (kind == 1) REQUIRE(cube->lpVtbl->UnlockRect(cube, face, 1));
+                    else if (kind == 2) REQUIRE(volume->lpVtbl->UnlockBox(volume, 1));
+                    else REQUIRE(flat->lpVtbl->UnlockRect(flat, 1));
+                }
+                for (path = 0; path < 2; path++) {
+                    D3D11_MAPPED_SUBRESOURCE mapped;
+                    d3d8_shaders_prepare_draw(D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1);
+                    if (path && !d3d8_combiners_prepare_draw()) return 1;
+                    ID3D11DeviceContext_VSSetShader(context, vs, NULL, 0);
+                    ID3D11DeviceContext_IASetInputLayout(context, NULL);
+                    ID3D11DeviceContext_IASetPrimitiveTopology(context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+                    ID3D11DeviceContext_Draw(context, 3, 0);
+                    ID3D11DeviceContext_CopyResource(context, (ID3D11Resource *)readback, (ID3D11Resource *)target);
+                    REQUIRE(ID3D11DeviceContext_Map(context, (ID3D11Resource *)readback, 0, D3D11_MAP_READ, 0, &mapped));
+                    if (memcmp(mapped.pData, expected, 4)) {
+                        BYTE *got = mapped.pData;
+                        fprintf(stderr, "FAIL kind=%u stage=%u format=0x%x alpha=%u path=%s: RGBA=%u,%u,%u,%u\n",
+                            kind, stage, formats[f], alphas[a], path ? "combiner" : "fixed",
+                            got[0], got[1], got[2], got[3]);
+                        failures++;
+                    }
+                    ID3D11DeviceContext_Unmap(context, (ID3D11Resource *)readback, 0);
+                }
+            }
+            textures[stage] = NULL;
+            srv = NULL;
+            ID3D11DeviceContext_PSSetShaderResources(context, stage, 1, &srv);
+            tex->lpVtbl->Release(tex);
+        }
+    }
+    ID3D11DeviceContext_ClearState(context);
+    d3d8_combiners_shutdown();
+    d3d8_shaders_shutdown();
+    ID3D11RasterizerState_Release(rasterizer);
+    ID3D11SamplerState_Release(sampler);
+    ID3D11VertexShader_Release(vs);
+    ID3D11RenderTargetView_Release(rtv);
+    ID3D11Texture2D_Release(target);
+    ID3D11Texture2D_Release(readback);
+    ID3D11DeviceContext_Release(context);
+    ID3D11Device_Release(device);
+    printf("d3d8_a8: %d failures (288 draws)\n", failures);
+    return failures != 0;
+}


### PR DESCRIPTION
## Problem

Xbox A8 textures should sample as `(1, 1, 1, alpha)`, but the D3D11 A8 sampling path supplies zero RGB. Both fixed-function and register-combiner pixel shaders therefore produce incorrect color when using an alpha-only texture.

There is a second part of the same draw-path defect: successful programmable vertex-shader preparation skips fixed-function pixel-state refresh. Texture changes can then leave the previous draw's pixel shader/constants active, including stale A8 metadata.

## Change

- Carry one alpha-only flag per texture stage in the fixed-function and combiner constant buffers; restore white RGB after sampling without changing alpha.
- Handle both `D3DFMT_A8` and `D3DFMT_LIN_A8`, without changing ordinary RGBA sampling or disabled combiner stages.
- Read volume-texture format from its actual structure layout; its depth field makes the 2D texture overlay incorrect.
- Centralize vertex/pixel preparation in `d3d8_shaders_prepare_draw`: select programmable or fixed-function vertex state, then refresh pixel state independently. All four device draw entry points use this path. Active combiners still override the fixed-function pixel shader afterward.

The implementation does not expand alpha-only texture storage or add shader variants for the A8 flag.

## Validation

Refreshed and tested against upstream `bc528f1d15d3bc681bee3d50ad1d1c88f307d394` on Windows with MSVC x64, Release:

```powershell
cmake -S . -B build -G "Visual Studio 17 2022" -A x64
cmake --build build --config Release --target xbox_d3d8 d3d8_a8 d3d8_smoke
./build/src/d3d/d3d8_smoke/Release/d3d8_a8.exe
./build/src/d3d/d3d8_smoke/Release/d3d8_smoke.exe
```

- Library build passed.
- A8 regression: **336 WARP draws, 0 failures**, with real shader compilation and pixel readback.
- Covers 2D/cube/volume textures, mip level 1, all four stages, alpha values 0/1/127/255, A8/LIN_A8 and ordinary RGBA controls, and both fixed-function and combiner pixel paths.
- Programmable-VS transition cases switch A8/RGBA state and verify the bound vertex shader, input layout, and vertex constant buffer are preserved. Vertex-shader preparation is modeled with real D3D11 state; this does not test Xbox vertex-microcode translation.
- Existing format/swizzle smoke test: all pass.
- `git diff --check origin/main...HEAD` passed.

No game data or generated game code are included. Validation uses WARP, not a hardware-adapter or full-game acceptance run.

## Merge

Independent PR targeting `main`; no prerequisite PRs. Proposed merge method: squash (the two fix commits form one A8 sampling correction).
