### PR TITLE
fix(apu): handle XAudio2 startup failures and rejected buffers safely

### DIFF
--- a/src/apu/apu_xaudio2.c
+++ b/src/apu/apu_xaudio2.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "apu_xaudio2.h"
 
 /* The XAudio2 backend is Windows-only. On Linux all xa2_* functions are
  * stubbed to report inactive; real audio output via SDL2 comes later. */
@@ -37,27 +38,29 @@ static int                     g_xa2_frames_written = 0;
 int xa2_init(void)
 {
     HRESULT hr;
+    int com_initialized;
     WAVEFORMATEX wfx = { 0 };
 
+    if (g_xa2_initialized) return 1;
+
     hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
-    if (FAILED(hr) && hr != (HRESULT)0x80010106 /* RPC_E_CHANGED_MODE */ && hr != S_FALSE) {
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
         fprintf(stderr, "[XA2] CoInitializeEx failed: 0x%08lX\n", hr);
         return 0;
     }
+    com_initialized = SUCCEEDED(hr);
 
     hr = XAudio2Create(&g_xa2, 0, XAUDIO2_DEFAULT_PROCESSOR);
     if (FAILED(hr) || !g_xa2) {
         fprintf(stderr, "[XA2] XAudio2Create failed: 0x%08lX\n", hr);
-        return 0;
+        goto fail;
     }
 
     hr = IXAudio2_CreateMasteringVoice(g_xa2, &g_xa2_master,
         XA2_CHANNELS, XA2_SAMPLE_RATE, 0, NULL, NULL, 0);
     if (FAILED(hr)) {
         fprintf(stderr, "[XA2] CreateMasteringVoice failed: 0x%08lX\n", hr);
-        IXAudio2_Release(g_xa2);
-        g_xa2 = NULL;
-        return 0;
+        goto fail;
     }
 
     wfx.wFormatTag      = WAVE_FORMAT_PCM;
@@ -71,13 +74,14 @@ int xa2_init(void)
         &wfx, 0, XAUDIO2_DEFAULT_FREQ_RATIO, NULL, NULL, NULL);
     if (FAILED(hr)) {
         fprintf(stderr, "[XA2] CreateSourceVoice failed: 0x%08lX\n", hr);
-        g_xa2_master->lpVtbl->DestroyVoice(g_xa2_master);
-        IXAudio2_Release(g_xa2);
-        g_xa2 = NULL;
-        return 0;
+        goto fail;
     }
 
-    IXAudio2SourceVoice_Start(g_xa2_source, 0, XAUDIO2_COMMIT_NOW);
+    hr = IXAudio2SourceVoice_Start(g_xa2_source, 0, XAUDIO2_COMMIT_NOW);
+    if (FAILED(hr)) {
+        fprintf(stderr, "[XA2] Start failed: 0x%08lX\n", hr);
+        goto fail;
+    }
 
     g_xa2_next_buf = 0;
     g_xa2_initialized = 1;
@@ -86,12 +90,16 @@ int xa2_init(void)
     fprintf(stderr, "[XA2] XAudio2 initialized (%d Hz stereo 16-bit, %d x %d-sample buffers)\n",
             XA2_SAMPLE_RATE, XA2_NUM_BUFS, XA2_BUF_SAMPLES);
     return 1;
+
+fail:
+    xa2_shutdown();
+    /* Failed initialization still runs on the COM-initializing thread. */
+    if (com_initialized) CoUninitialize();
+    return 0;
 }
 
 void xa2_shutdown(void)
 {
-    if (!g_xa2_initialized) return;
-
     if (g_xa2_source) {
         IXAudio2SourceVoice_Stop(g_xa2_source, 0, XAUDIO2_COMMIT_NOW);
         IXAudio2SourceVoice_FlushSourceBuffers(g_xa2_source);
@@ -107,7 +115,8 @@ void xa2_shutdown(void)
         g_xa2 = NULL;
     }
 
-    fprintf(stderr, "[XA2] Shut down (%d frames written)\n", g_xa2_frames_written);
+    if (g_xa2_initialized)
+        fprintf(stderr, "[XA2] Shut down (%d frames written)\n", g_xa2_frames_written);
     g_xa2_initialized = 0;
 }
 
@@ -124,6 +133,7 @@ int xa2_submit_samples(const int16_t *samples, int num_samples)
     XAUDIO2_BUFFER xbuf;
     int idx;
     int copy_samples;
+    HRESULT hr;
 
     if (!g_xa2_initialized || !g_xa2_source) return 0;
 
@@ -138,7 +148,8 @@ int xa2_submit_samples(const int16_t *samples, int num_samples)
     xbuf.AudioBytes = copy_samples * XA2_CHANNELS * sizeof(int16_t);
     xbuf.pAudioData = (const BYTE *)g_xa2_bufs[idx];
 
-    IXAudio2SourceVoice_SubmitSourceBuffer(g_xa2_source, &xbuf, NULL);
+    hr = IXAudio2SourceVoice_SubmitSourceBuffer(g_xa2_source, &xbuf, NULL);
+    if (FAILED(hr)) return 0;
 
     g_xa2_next_buf = (idx + 1) % XA2_NUM_BUFS;
     g_xa2_frames_written++;

--- a/tests/xaudio2/CMakeLists.txt
+++ b/tests/xaudio2/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(xaudio2_test C)
+set(CMAKE_C_STANDARD 11)
+add_executable(xaudio2_test test_main.c)
+enable_testing()
+add_test(NAME xaudio2_test COMMAND xaudio2_test)

--- a/tests/xaudio2/test_main.c
+++ b/tests/xaudio2/test_main.c
@@ -1,0 +1,193 @@
+/* Windows SDK only; no audio device required.
+ * cmake -S tests/xaudio2 -B build/xaudio2-test
+ * cmake --build build/xaudio2-test --config Debug
+ * ctest --test-dir build/xaudio2-test -C Debug --output-on-failure
+ */
+#define COBJMACROS
+#include <windows.h>
+#include <xaudio2.h>
+#include <stdio.h>
+#include <string.h>
+
+static HRESULT com_result, create_result, master_result, source_result;
+static HRESULT start_result, submit_result;
+static int com_refs, releases, master_destroys, source_destroys, failures;
+static IXAudio2 engine;
+static IXAudio2MasteringVoice master;
+static IXAudio2SourceVoice source;
+static IXAudio2MasteringVoiceVtbl master_vtable;
+static IXAudio2SourceVoiceVtbl source_vtable;
+static const BYTE *queued[3];
+static BYTE snapshots[3][4096];
+static UINT32 queued_bytes[3], queue_count;
+
+#define CHECK(test) do { if (!(test)) { \
+    fprintf(stderr, "FAIL line %d: %s\n", __LINE__, #test); failures++; \
+} } while (0)
+
+static HRESULT fake_com_init(void)
+{
+    if (SUCCEEDED(com_result)) com_refs++;
+    return com_result;
+}
+
+static HRESULT fake_create(IXAudio2 **out)
+{
+    if (SUCCEEDED(create_result)) *out = &engine;
+    return create_result;
+}
+
+static HRESULT fake_master(IXAudio2MasteringVoice **out)
+{
+    if (SUCCEEDED(master_result)) *out = &master;
+    return master_result;
+}
+
+static HRESULT fake_source(IXAudio2SourceVoice **out)
+{
+    if (SUCCEEDED(source_result)) *out = &source;
+    return source_result;
+}
+
+static void STDMETHODCALLTYPE destroy_master(IXAudio2MasteringVoice *voice)
+{
+    CHECK(voice == &master);
+    master_destroys++;
+}
+
+static void STDMETHODCALLTYPE destroy_source(IXAudio2SourceVoice *voice)
+{
+    CHECK(voice == &source);
+    source_destroys++;
+    queue_count = 0;
+}
+
+static void check_queued(void)
+{
+    for (UINT32 i = 0; i < queue_count; i++)
+        CHECK(memcmp(queued[i], snapshots[i], queued_bytes[i]) == 0);
+}
+
+static void fake_state(XAUDIO2_VOICE_STATE *state)
+{
+    memset(state, 0, sizeof(*state));
+    state->BuffersQueued = queue_count;
+}
+
+static HRESULT fake_submit(const XAUDIO2_BUFFER *buffer)
+{
+    check_queued();
+    if (FAILED(submit_result)) return submit_result;
+    CHECK(queue_count < 3);
+    if (queue_count == 3) return E_FAIL;
+    queued[queue_count] = buffer->pAudioData;
+    queued_bytes[queue_count] = buffer->AudioBytes;
+    memcpy(snapshots[queue_count], buffer->pAudioData, buffer->AudioBytes);
+    queue_count++;
+    return S_OK;
+}
+
+/* Replace only external APIs; compile the real backend, including its ring. */
+#define CoInitializeEx(...) fake_com_init()
+#define CoUninitialize() ((void)--com_refs)
+#define XAudio2Create(out, ...) fake_create(out)
+#undef IXAudio2_CreateMasteringVoice
+#define IXAudio2_CreateMasteringVoice(engine, out, ...) fake_master(out)
+#undef IXAudio2_CreateSourceVoice
+#define IXAudio2_CreateSourceVoice(engine, out, ...) fake_source(out)
+#undef IXAudio2_Release
+#define IXAudio2_Release(...) ((void)++releases)
+#undef IXAudio2SourceVoice_Start
+#define IXAudio2SourceVoice_Start(...) start_result
+#undef IXAudio2SourceVoice_Stop
+#define IXAudio2SourceVoice_Stop(...) ((void)0)
+#undef IXAudio2SourceVoice_FlushSourceBuffers
+#define IXAudio2SourceVoice_FlushSourceBuffers(...) ((void)0)
+#undef IXAudio2SourceVoice_GetState
+#define IXAudio2SourceVoice_GetState(source, state, ...) fake_state(state)
+#undef IXAudio2SourceVoice_SubmitSourceBuffer
+#define IXAudio2SourceVoice_SubmitSourceBuffer(source, buffer, ...) fake_submit(buffer)
+#include "../../src/apu/apu_xaudio2.c"
+
+static void reset(void)
+{
+    /* Fake resources are static, so even a broken cleanup can be reset. */
+    g_xa2 = NULL;
+    g_xa2_master = NULL;
+    g_xa2_source = NULL;
+    g_xa2_initialized = 0;
+    com_refs = releases = master_destroys = source_destroys = 0;
+    queue_count = 0;
+    com_result = create_result = master_result = source_result = S_OK;
+    start_result = submit_result = S_OK;
+}
+
+static void check_init_failures(HRESULT com_hr)
+{
+    HRESULT *stages[] = { &create_result, &master_result, &source_result, &start_result };
+    for (int stage = 0; stage < 4; stage++) {
+        reset();
+        com_result = com_hr;
+        *stages[stage] = E_FAIL;
+        CHECK(xa2_init() == 0);
+        CHECK(!xa2_is_active());
+        CHECK(com_refs == 0);
+        CHECK(releases == (stage >= 1));
+        CHECK(master_destroys == (stage >= 2));
+        CHECK(source_destroys == (stage >= 3));
+        CHECK(!g_xa2 && !g_xa2_master && !g_xa2_source);
+        xa2_shutdown();
+        CHECK(releases == (stage >= 1));
+    }
+}
+
+int main(void)
+{
+    master_vtable.DestroyVoice = destroy_master;
+    source_vtable.DestroyVoice = destroy_source;
+    master.lpVtbl = &master_vtable;
+    source.lpVtbl = &source_vtable;
+    check_init_failures(S_OK);
+    check_init_failures(S_FALSE);
+    check_init_failures(RPC_E_CHANGED_MODE);
+    reset();
+    com_result = E_FAIL;
+    CHECK(xa2_init() == 0 && !xa2_is_active() && com_refs == 0);
+
+    reset();
+    CHECK(xa2_init() == 1 && xa2_is_active());
+    CHECK(xa2_init() == 1 && com_refs == 1);
+    int16_t samples[1024][2];
+    memset(samples, 1, sizeof(samples));
+    CHECK(xa2_submit_samples(&samples[0][0], 1024) == 1);
+    submit_result = E_FAIL;
+    for (int i = 0; i < 3; i++) {
+        memset(samples, 2 + i, sizeof(samples));
+        CHECK(xa2_submit_samples(&samples[0][0], 1024) == 0);
+        CHECK(g_xa2_next_buf == 1 && g_xa2_frames_written == 1);
+        check_queued();
+    }
+    submit_result = S_OK;
+    CHECK(xa2_submit_samples(&samples[0][0], 1024) == 1);
+    CHECK(xa2_submit_samples(&samples[0][0], 1024) == 1);
+    CHECK(xa2_submit_samples(&samples[0][0], 1024) == 0);
+    CHECK(g_xa2_frames_written == 3);
+    check_queued();
+    /* Complete the oldest buffer, then wrap the ring into that free slot. */
+    for (UINT32 i = 0; i < 2; i++) {
+        queued[i] = queued[i + 1];
+        queued_bytes[i] = queued_bytes[i + 1];
+        memcpy(snapshots[i], snapshots[i + 1], queued_bytes[i]);
+    }
+    queue_count--;
+    memset(samples, 9, sizeof(samples));
+    CHECK(xa2_submit_samples(&samples[0][0], 1024) == 1);
+    check_queued();
+    xa2_shutdown();
+    CHECK(!xa2_is_active() && releases == 1);
+    CHECK(master_destroys == 1 && source_destroys == 1);
+    xa2_shutdown();
+    CHECK(releases == 1 && master_destroys == 1 && source_destroys == 1);
+    printf("XAudio2 regression: %d failures\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Problem

The XAudio2 backend ignores failures from `Start` and `SubmitSourceBuffer`. A failed start can report the backend as active. A rejected buffer can report success, advance the ring, and increment the accepted-frame counter; repeated failures can eventually reuse storage that is still queued for playback.

Initialization failures also leave cleanup inconsistent because shutdown previously returned immediately unless initialization had completed.

## Change

- Check voice-start status and report initialization failure when playback cannot start.
- Use one partial-initialization cleanup path for engine and voice resources; repeated shutdown remains safe.
- Balance a successful `CoInitializeEx` call when initialization fails, on that same thread. Do not uninitialize COM for `RPC_E_CHANGED_MODE`.
- Make repeated successful initialization idempotent.
- Return failure on rejected buffer submission without advancing the ring or accepted-frame counter.

Successful-lifetime COM teardown is deliberately unchanged: the public initialization/shutdown callers do not establish a same-thread guarantee, so adding unconditional `CoUninitialize` to shutdown would be unsafe.

## Validation

Refreshed and tested against upstream `bc528f1d15d3bc681bee3d50ad1d1c88f307d394` on Windows with MSVC x64:

```powershell
cmake -S . -B build/runtime -G "Visual Studio 17 2022" -A x64
cmake --build build/runtime --config Release --target xbox_apu
cmake -S tests/xaudio2 -B build/xaudio2-test -G "Visual Studio 17 2022" -A x64
cmake --build build/xaudio2-test --config Debug
ctest --test-dir build/xaudio2-test -C Debug --output-on-failure
```

- Release `xbox_apu` build passed.
- Regression test: 1/1 passed, 0 failures.
- The test compiles the real backend and replaces only external APIs with deterministic fakes. It covers failures at every initialization stage, COM outcomes, repeated initialization/shutdown, rejected submissions, queue saturation, ring wrap, and preservation of queued sample bytes.
- During initial reproduction, this regression reported 41 failures before the fix.
- `git diff --check origin/main...HEAD` passed.

No audio device or game data is required. This validates failure handling and queue ownership, not audible output or real-device recovery.

## Merge

Independent PR targeting `main`; no prerequisite PRs. Proposed merge method: squash.
