### PR TITLE
fix(lifter): translate unsigned saturating MMX word add and subtract

### DIFF
--- a/templates/runtime/recomp_types.h
+++ b/templates/runtime/recomp_types.h
@@ -959,6 +959,10 @@ static inline uint8_t recomp_sat_u8(int32_t v) {
     return (uint8_t)(v > 255 ? 255 : (v < 0 ? 0 : v));
 }
 
+static inline uint16_t recomp_sat_u16(int32_t v) {
+    return (uint16_t)(v > 65535 ? 65535 : (v < 0 ? 0 : v));
+}
+
 /* -- integer arithmetic, lane-wise, wrapping -------------------- */
 #define RECOMP_MMX_BINOP(NAME, LANES, FIELD, EXPR)                      \
     static inline RecompMmx NAME(RecompMmx a, RecompMmx b) {            \
@@ -981,6 +985,10 @@ RECOMP_MMX_BINOP(MMX_PADDUSB, 8, ub,
                  recomp_sat_u8((int32_t)a.ub[i] + b.ub[i]))
 RECOMP_MMX_BINOP(MMX_PSUBUSB, 8, ub,
                  recomp_sat_u8((int32_t)a.ub[i] - b.ub[i]))
+RECOMP_MMX_BINOP(MMX_PADDUSW, 4, uw,
+                 recomp_sat_u16((int32_t)a.uw[i] + b.uw[i]))
+RECOMP_MMX_BINOP(MMX_PSUBUSW, 4, uw,
+                 recomp_sat_u16((int32_t)a.uw[i] - b.uw[i]))
 RECOMP_MMX_BINOP(MMX_PMULLW, 4, w, (int16_t)((int32_t)a.w[i] * b.w[i]))
 RECOMP_MMX_BINOP(MMX_PMULHW, 4, w, (int16_t)(((int32_t)a.w[i] * b.w[i]) >> 16))
 RECOMP_MMX_BINOP(MMX_PAVGB, 8, ub, (uint8_t)(((int32_t)a.ub[i] + b.ub[i] + 1) >> 1))

--- a/tools/conformance/cases.py
+++ b/tools/conformance/cases.py
@@ -416,6 +416,26 @@ CASES = [
     Case("js_cmp_i8", "sign flag after an 8-bit cmp, which truncates first",
          ["cmp al, cl", "sets al", "movzx eax, al"], _PAIRS),
 
+    # Unsigned word saturation must clamp each lane, not wrap or drop the op.
+    *[Case("mmx_" + op + "_" + form + "_" + str(half),
+           "unsigned word arithmetic saturates all four lanes",
+           ["movd mm0, eax", "punpckldq mm0, mm0",
+            "movd mm1, ecx", "punpckldq mm1, mm1"]
+           + ([op + " mm0, mm1"] if form == "reg" else
+              ["sub esp, 8", "movq qword ptr [esp], mm1",
+               op + " mm0, qword ptr [esp]", "add esp, 8"])
+           + (["psrlq mm0, 32"] if half else [])
+           + ["sub esp, 8", "movq qword ptr [esp], mm0",
+              "mov eax, dword ptr [esp]", "add esp, 8", "emms"],
+           [(a, b) for a in (0, 1, 0x0001ffff, 0x80007fff, 0xfffeffff, 0xffffffff)
+                   for b in (0, 1, 0x0001ffff, 0x80007fff, 0xfffeffff, 0xffffffff)])
+      for op in ("paddusw", "psubusw") for form in ("reg", "mem") for half in (0, 1)],
+
+    *[Case("mmx_" + op + "_flags", "unsigned saturated arithmetic preserves EFLAGS",
+           ["pxor mm0, mm0", "pxor mm1, mm1", "cmp eax, 0", op + " mm0, mm1",
+            "sete al", "movzx eax, al", "emms"], [(0, 0), (1, 0)])
+      for op in ("paddusw", "psubusw")],
+
     # bt/btr/bts/btc are 386 instructions, so real Xbox code has them. They
     # were unhandled until the corpus lifted the CRT's float-to-int helper,
     # which uses btr to clear a rounding-control bit of the x87 control word.

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -324,6 +324,7 @@ _EFLAGS_PRESERVE = frozenset({
     "punpckhbw", "punpckhwd", "punpckhdq", "punpckhqdq",
     "packsswb", "packssdw", "packuswb",
     "pmovmskb",
+    "paddusw", "psubusw",
     # String operations (without rep prefix)
     "stosb", "stosw", "stosd",
     "movsb", "movsw", "movsd",
@@ -2222,6 +2223,7 @@ class Lifter:
         "paddsb": "MMX_PADDSB", "paddsw": "MMX_PADDSW",
         "psubsb": "MMX_PSUBSB", "psubsw": "MMX_PSUBSW",
         "paddusb": "MMX_PADDUSB", "psubusb": "MMX_PSUBUSB",
+        "paddusw": "MMX_PADDUSW", "psubusw": "MMX_PSUBUSW",
         "pmullw": "MMX_PMULLW", "pmulhw": "MMX_PMULHW",
         "pmaddwd": "MMX_PMADDWD",
         "pavgb": "MMX_PAVGB", "pavgw": "MMX_PAVGW",


### PR DESCRIPTION
## Problem

The MMX path supports unsigned saturating byte arithmetic, but omits unsigned saturating **word** arithmetic. `PADDUSW` and `PSUBUSW` become TODO comments while surrounding MOVQ loads/stores still execute. A store can therefore publish an unchanged value instead of the saturated result.

This came from checking whether the local incomplete-MMX-function guard was still needed upstream. The narrow fix here implements these two missing producers; it does not introduce a global guard or claim that every MMX form is supported.

## Change

- Add PADDUSW and PSUBUSW dispatch through the existing MMX binary-operation path, including register and memory operands.
- Reuse the existing lane-wise helper pattern with a uint16 saturation helper. Addition clamps at 65535 and subtraction at zero.
- Mark both instructions as preserving EFLAGS.
- Add CPU-conformance cases for zero, saturation boundaries, mixed lanes, both halves of the result, memory/register sources, MOVQ stores and a following SETE.

## Validation

Base: upstream `051a128df5ec27ef14f1ceaaead11c5457321eef`.

```text
python -m tools.conformance --only snippets -k mmx_p
python -m tools.conformance
python -m pytest tools/ -q --tb=short
```

- Before fix, the focused run reported 192 mismatches and eight comment-only instruction sites (the filter also includes existing MMX cases).
- After fix, the full 32-bit MSVC run passed 5,171 instruction vectors and 211 function vectors with 0 mismatches. This includes 292 added vectors.
- Python suite: 220 passed, 10 subtests passed.
- `git diff --check` passed.

All inputs are synthetic. No game data, generated game code or gameplay acceptance claim is included. XMM/SSE2 forms and other missing MMX operations are outside this patch.

Independent PR targeting `main`, no prerequisites. Proposed merge method: squash.
