### PR TITLE
fix(lifter): preserve comparisons across 15 MMX instruction forms

### DIFF
--- a/tools/conformance/cases.py
+++ b/tools/conformance/cases.py
@@ -440,3 +440,22 @@ CASES = [
          ["fld qword ptr [eax+16]", "fld qword ptr [eax]", "fucompp",
           "fnstsw ax", "and eax, 04500h"], _FP_NAN, "fpu"),
 ]
+
+# MMX arithmetic/conversions preserve EFLAGS. Exercise the deferred condition,
+# not only the MMX result, with both true and false incoming comparisons.
+for _op in (
+        "paddsb mm0, mm1", "paddsw mm0, mm1", "paddusb mm0, mm1",
+        "psubsb mm0, mm1", "psubsw mm0, mm1", "psubusb mm0, mm1",
+        "pavgb mm0, mm1", "pavgw mm0, mm1", "pminsw mm0, mm1",
+        "pmaxsw mm0, mm1", "psadbw mm0, mm1",
+        "cvtps2pi mm0, xmm0", "cvttps2pi mm0, xmm0",
+        "pinsrw mm0, ecx, 0", "pextrw edx, mm0, 0"):
+    for _consumer, _before, _after in (
+            ("sete", ["cmp eax, 0"], ["sete al", "movzx eax, al"]),
+            ("cmove", ["cmp eax, 0"], ["cmove eax, ecx"]),
+            ("sbb", ["neg eax"], ["sbb eax, eax"])):
+        CASES.append(Case(
+            "mmx_flags_" + _op.split()[0] + "_" + _consumer,
+            "MMX preserves the comparison/carry consumed afterward",
+            ["pxor mm0, mm0", "pxor mm1, mm1", "xorps xmm0, xmm0"]
+            + _before + [_op] + _after + ["emms"], [(0, 7), (1, 7)]))

--- a/tools/recomp/lifter.py
+++ b/tools/recomp/lifter.py
@@ -309,9 +309,12 @@ _EFLAGS_PRESERVE = frozenset({
     "addpd", "subpd", "mulpd", "divpd",
     # SSE/MMX integer
     "movd", "movq", "movntq",
+    "cvtps2pi", "cvttps2pi", "pinsrw", "pextrw",
     "emms",
     "paddb", "paddw", "paddd", "paddq",
     "psubb", "psubw", "psubd",
+    "paddsb", "paddsw", "paddusb", "psubsb", "psubsw", "psubusb",
+    "pavgb", "pavgw", "pminsw", "pmaxsw", "psadbw",
     "pmullw", "pmulhw", "pmulhuw", "pmaddwd",
     "pand", "pandn", "por", "pxor",
     "pcmpeqb", "pcmpeqw", "pcmpeqd",


### PR DESCRIPTION
## Problem

Several implemented MMX instructions are absent from `_EFLAGS_PRESERVE`. The lifter consequently loses the preceding comparison and falls back to `_flags` for a later SETcc or CMOVcc, even though the real instruction preserves EFLAGS.

A synthetic `cmp eax, 0; pavgb mm0, mm1; sete al` returns 1 on the CPU when eax is zero, but the lifted code returns 0. Checking the same path found 15 affected instruction forms: signed/unsigned byte and signed-word saturation, averages, min/max, sum of absolute differences, CVTPS2PI/CVTTPS2PI, PINSRW and PEXTRW.

## Change

Add the missing mnemonics to the existing preservation set. No instruction implementation or runtime ABI changes are needed. Add native-vs-lifted conformance cases for SETE, CMOVE and SBB, with both zero and nonzero inputs.

This does not duplicate #28's carry-dependent CMOV declaration fix: these cases exercise retained comparison state, not a missing `_cf` declaration.

## Validation

Base: upstream `051a128df5ec27ef14f1ceaaead11c5457321eef`.

```text
python -m tools.conformance --only snippets -k mmx_flags
python -m tools.conformance
python -m pytest tools/ -q --tb=short
```

- New regression before fix: 90 vectors, 30 mismatches.
- New regression after fix: 90 vectors, 0 mismatches.
- Full 32-bit MSVC CPU conformance: 4,969 instruction vectors and 211 function vectors, 0 mismatches.
- Python suite: 220 passed, 10 subtests passed.
- `git diff --check` passed.

All inputs are synthetic; no game data or generated game code is included. No game build or runtime acceptance run was performed for this patch.

Independent PR targeting `main`, no prerequisites. Proposed merge method: squash.
