### PR TITLE
fix(d3d8): prevent invalid alpha blend states for color factors

### DIFF
--- a/src/d3d/d3d8_states.c
+++ b/src/d3d/d3d8_states.c
@@ -50,6 +50,18 @@ static D3D11_BLEND d3d8_to_d3d11_blend(DWORD d3d8blend)
     }
 }
 
+/* D3D11 forbids color factors in the alpha channel. Use their alpha components. */
+static D3D11_BLEND blend_alpha_factor(D3D11_BLEND blend)
+{
+    switch (blend) {
+    case D3D11_BLEND_SRC_COLOR:      return D3D11_BLEND_SRC_ALPHA;
+    case D3D11_BLEND_INV_SRC_COLOR:  return D3D11_BLEND_INV_SRC_ALPHA;
+    case D3D11_BLEND_DEST_COLOR:     return D3D11_BLEND_DEST_ALPHA;
+    case D3D11_BLEND_INV_DEST_COLOR: return D3D11_BLEND_INV_DEST_ALPHA;
+    default:                       return blend;
+    }
+}
+
 static D3D11_COMPARISON_FUNC d3d8_to_d3d11_cmp(DWORD d3d8cmp)
 {
     switch (d3d8cmp) {
@@ -131,8 +143,8 @@ static void update_blend_state(const DWORD *rs)
     bd.RenderTarget[0].SrcBlend = d3d8_to_d3d11_blend(rs[D3DRS_SRCBLEND]);
     bd.RenderTarget[0].DestBlend = d3d8_to_d3d11_blend(rs[D3DRS_DESTBLEND]);
     bd.RenderTarget[0].BlendOp = d3d8_to_d3d11_blendop(rs[D3DRS_BLENDOP] ? rs[D3DRS_BLENDOP] : 1);
-    bd.RenderTarget[0].SrcBlendAlpha = bd.RenderTarget[0].SrcBlend;
-    bd.RenderTarget[0].DestBlendAlpha = bd.RenderTarget[0].DestBlend;
+    bd.RenderTarget[0].SrcBlendAlpha = blend_alpha_factor(bd.RenderTarget[0].SrcBlend);
+    bd.RenderTarget[0].DestBlendAlpha = blend_alpha_factor(bd.RenderTarget[0].DestBlend);
     bd.RenderTarget[0].BlendOpAlpha = bd.RenderTarget[0].BlendOp;
     bd.RenderTarget[0].RenderTargetWriteMask = (UINT8)(rs[D3DRS_COLORWRITEENABLE] & 0x0F);
 

--- a/tests/d3d8_smoke/test_states.c
+++ b/tests/d3d8_smoke/test_states.c
@@ -33,6 +33,44 @@ static D3D11_DEPTH_STENCIL_DESC apply(void)
     return desc;
 }
 
+static void check_blend_factors(void)
+{
+    static const struct { DWORD guest; D3D11_BLEND rgb, alpha; } cases[] = {
+        {D3DBLEND_SRCALPHA, D3D11_BLEND_SRC_ALPHA, D3D11_BLEND_SRC_ALPHA},
+        {D3DBLEND_SRCCOLOR, D3D11_BLEND_SRC_COLOR, D3D11_BLEND_SRC_ALPHA},
+        {D3DBLEND_INVSRCCOLOR, D3D11_BLEND_INV_SRC_COLOR, D3D11_BLEND_INV_SRC_ALPHA},
+        {D3DBLEND_DESTCOLOR, D3D11_BLEND_DEST_COLOR, D3D11_BLEND_DEST_ALPHA},
+        {D3DBLEND_INVDESTCOLOR, D3D11_BLEND_INV_DEST_COLOR, D3D11_BLEND_INV_DEST_ALPHA},
+        {D3DBLEND_ONE, D3D11_BLEND_ONE, D3D11_BLEND_ONE},
+        {D3DBLEND_ZERO, D3D11_BLEND_ZERO, D3D11_BLEND_ZERO}
+    };
+    unsigned side, i;
+    rs[D3DRS_ALPHABLENDENABLE] = TRUE;
+    for (side = 0; side < 2; side++) {
+        for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+            ID3D11BlendState *state = NULL;
+            D3D11_BLEND_DESC desc;
+            rs[D3DRS_SRCBLEND] = side ? D3DBLEND_ONE : cases[i].guest;
+            rs[D3DRS_DESTBLEND] = side ? cases[i].guest : D3DBLEND_ZERO;
+            d3d8_states_apply();
+            ID3D11DeviceContext_OMGetBlendState(context, &state, NULL, NULL);
+            CHECK("blend state bound", state != NULL);
+            if (!state) continue;
+            ID3D11BlendState_GetDesc(state, &desc);
+            /* A failed creation can leave the previous state bound. */
+            if (!desc.RenderTarget[0].BlendEnable ||
+                desc.RenderTarget[0].SrcBlend != (side ? D3D11_BLEND_ONE : cases[i].rgb) ||
+                desc.RenderTarget[0].DestBlend != (side ? cases[i].rgb : D3D11_BLEND_ZERO) ||
+                desc.RenderTarget[0].SrcBlendAlpha != (side ? D3D11_BLEND_ONE : cases[i].alpha) ||
+                desc.RenderTarget[0].DestBlendAlpha != (side ? cases[i].alpha : D3D11_BLEND_ZERO)) {
+                printf("FAIL: blend side=%u factor=%lu\n", side, cases[i].guest);
+                failures++;
+            }
+            ID3D11BlendState_Release(state);
+        }
+    }
+}
+
 int main(void)
 {
     D3D11_DEPTH_STENCIL_DESC desc;
@@ -111,6 +149,7 @@ int main(void)
     d3d8_states_init();
     desc = apply();
     CHECK("cache recreates after shutdown", desc.StencilWriteMask == 0x5A);
+    check_blend_factors();
     d3d8_states_shutdown();
     ID3D11DeviceContext_ClearState(context);
     ID3D11DeviceContext_Release(context);


### PR DESCRIPTION
## Problem

`update_blend_state()` copied the RGB blend factors directly into `SrcBlendAlpha` and `DestBlendAlpha`. D3D11 rejects color factors in those alpha fields, so guest `SRCCOLOR`, `INVSRCCOLOR`, `DESTCOLOR`, and `INVDESTCOLOR` states failed with `E_INVALIDARG` (`0x80070057`). The previously bound blend state could remain active instead of the requested state.

## Change

- Translate the four color factors to their corresponding alpha components for the alpha channel only.
- Preserve the requested RGB factors, blend operations, write mask, and existing cache behavior.
- Extend the existing WARP state smoke test with 14 source/destination cases, including SRCALPHA, ONE, and ZERO controls. Inspect the actual bound descriptor so a stale non-null state cannot produce a false pass.

This follows the restrictions on [D3D11 render-target blend descriptors](https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ns-d3d11-d3d11_render_target_blend_desc).

## Validation

Base: `051a128df5ec27ef14f1ceaaead11c5457321eef` (`main`). Windows, MSVC 19.44, x64 Release, D3D11 WARP.

- New regression against unchanged production code: **8 failures**, each accompanied by `CreateBlendState` returning `0x80070057`; controls passed.
- After the fix: `d3d8_states_smoke` **0 failures**.
- Built `xbox_d3d8`, `d3d8_states_smoke`, `d3d8_a8`, and `d3d8_smoke`.
- Existing A8 smoke: **336 draws, 0 failures**; format smoke: **all pass**.
- `python -m pytest tools/ -q`: **220 passed, 10 subtests passed**.
- `python -m tools.conformance`: **4,879 instruction vectors and 211 function vectors, 0 mismatches**.
- `git diff --check`: clean.

No game was run for this PR; validation is synthetic, headless WARP using the real state implementation. No game data, generated C, or dependencies are included.

## Merge shape

Independent PR against `main`, with no prerequisite PRs. Proposed merge: **squash**.
